### PR TITLE
Update rustc version grabber and test

### DIFF
--- a/functions/_tide_item_rustc.fish
+++ b/functions/_tide_item_rustc.fish
@@ -1,6 +1,6 @@
 function _tide_item_rustc
     if path is $_tide_parent_dirs/Cargo.toml
-        rustup show active-toolchain | string match -qr "(?<v>^[\d.]+)"
+        rustup show active-toolchain -v | string match -qr "rustc (?<v>\d+\.\d+\.\d+)"
         _tide_print_item rustc $tide_rustc_icon' ' $v
     end
 end

--- a/tests/_tide_item_rustc.test.fish
+++ b/tests/_tide_item_rustc.test.fish
@@ -8,12 +8,13 @@ end
 set -l rustcDir (mktemp -d)
 cd $rustcDir
 
-mock rustc --version "echo rustc 1.30.0"
+mock rustup \* "echo \"stable-x86_64-unknown-linux-gnu (default)\"; echo \"rustc 1.86.0 (05f9846f8 2025-03-31)\""
+
 set -lx tide_rustc_icon 
 
 _rustc # CHECK:
 
 touch Cargo.toml
-_rustc # CHECK:  1.30.0
+_rustc # CHECK:  1.86.0
 
 command rm -r $rustcDir


### PR DESCRIPTION
#### Description

The rust version checker does not match on the actual output of current versions of "rustup show active-toolchain" - have to use -v if using the default settings (install stable) and fetch the actual version from the second line.
