### PR TITLE
fix(pwd): Fix an issue where tide would error on a too long pwd

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -28,7 +28,7 @@ eval "function _tide_pwd
             string match -qr \"(?<trunc>\..|.)\" \$dir_section
 
             set -l glob \$parent_dir/\$trunc*/
-            set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob)] # This is faster than inverse string match
+            set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob | echo)] # This is faster than inverse string match
 
             while string match -qr \"^\$parent_dir/\$(string escape --style=regex \$trunc)\" \$glob &&
                     string match -qr \"(?<trunc>\$(string escape --style=regex \$trunc).)\" \$dir_section


### PR DESCRIPTION
See https://github.com/IlanCosman/tide/issues/499

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

The function being edited works fine otherwise, but adding the pipe into echo just removes a very annoying error message.

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

<!-- Why is this change required? What problem does it solve? -->

Closes #11  <!--- Please link to an open issue. -->

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
