### PR TITLE
Simplify terraform item and test w/ builtin

### DIFF
--- a/functions/_tide_item_terraform.fish
+++ b/functions/_tide_item_terraform.fish
@@ -1,6 +1,6 @@
 function _tide_item_terraform
     path is $_tide_parent_dirs/.terraform &&
-        which terraform >/dev/null &&
+        type -q terraform &&
         terraform workspace show | string match -v default | read -l w &&
         _tide_print_item terraform $tide_terraform_icon' ' $w
 end

--- a/tests/_tide_item_terraform.test.fish
+++ b/tests/_tide_item_terraform.test.fish
@@ -10,7 +10,6 @@ set -lx tide_terraform_icon 󱁢
 set -l terraformDir (mktemp -d)
 cd $terraformDir
 
-mock which terraform "echo /usr/local/bin/terraform"
 mock terraform "workspace show" "echo default"
 _terraform # CHECK:
 


### PR DESCRIPTION
There is no reason to use which when a shell builtin will do.

#### Description

Remove dependency on `which` from the terraform item.

- [x] I have updated the tests accordingly.
