### PR TITLE
Re-evaluate installed tools on path changes

### DIFF
--- a/functions/_tide_remove_unusable_items.fish
+++ b/functions/_tide_remove_unusable_items.fish
@@ -1,4 +1,4 @@
-function _tide_remove_unusable_items
+function _tide_remove_unusable_items --on-variable PATH
     # Remove tool-specific items for tools the machine doesn't have installed
     set -l removed_items
     for item in aws bun crystal direnv distrobox docker elixir gcloud git go java kubectl nix_shell node php pulumi python ruby rustc terraform toolbox zig


### PR DESCRIPTION
#### Description

Trigger item enumeration whenever the PATH environment changes. 

#### Motivation and Context

This allows for more dynamic setups involving `direnv` and similar helpers to automatically bring in new items without needing to spawn a new shell.

Closes #13 

#### How Has This Been Tested

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [] I have updated the tests accordingly.
