### PR TITLE
Check interactivity before clearing terminal

### DIFF
--- a/functions/tide/configure/choices/all/finish.fish
+++ b/functions/tide/configure/choices/all/finish.fish
@@ -14,7 +14,7 @@ function finish
     switch $_tide_selected_option
         case 'Overwrite your current tide config'
             _tide_finish
-            command -q clear && clear
+            command -q clear && status is-interactive && clear
             set -q _flag_auto || _tide_print_configure_current_options
         case 'Exit and print the config you just generated'
             _tide_exit_configure


### PR DESCRIPTION
#### Description

Check that the shell is interactive before clearing screen at the end of configuration.

#### Motivation and Context

If running `tide configure --auto` as part of some larger non-interactive process i.e. in the context of some dotfiles manager then clearing the screen is quite jarring as it removes the logs of the parent process.

The patch adds an interactivity check to keep the current behaviour when running `tide configure` in a tty, but makes it a better behaved citizen in automation contexts.

#### How Has This Been Tested

I have been running this patch for a month or so, I run `tide configure --auto` automatically when pulling dotfiles changes, the patch does it what claims.

- [x] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
