### PR TITLE
Forward fish_key_bindings for fish 4.3 changes

### DIFF
--- a/functions/_tide_item_character.fish
+++ b/functions/_tide_item_character.fish
@@ -3,7 +3,9 @@ function _tide_item_character
 
     set -q add_prefix || echo -ns ' '
 
-    test "$fish_key_bindings" = fish_default_key_bindings && echo -ns $tide_character_icon ||
+    if test "$fish_key_bindings" = fish_default_key_bindings || test -z "$fish_key_bindings"
+        echo -ns $tide_character_icon
+    else
         switch $fish_bind_mode
             case insert
                 echo -ns $tide_character_icon
@@ -14,4 +16,5 @@ function _tide_item_character
             case visual
                 echo -ns $tide_character_vi_icon_visual
         end
+    end
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -44,7 +44,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null
@@ -82,7 +82,7 @@ function fish_prompt
         jobs -q && jobs -p | count | read -lx _tide_jobs
         $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
         builtin disown
 
         command kill \$_tide_last_pid 2>/dev/null


### PR DESCRIPTION
This patch is forward-ported from https://github.com/IlanCosman/tide/pull/619 and fixes an inverted prompt sign

**Personal note:** thanks for keeping the project alive and maintained! There's one annoying issue in tide that still bothers me, and I would like to contribute the existing fix from the upstream repo to this fork.

<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

In [fish 4.3.0](https://github.com/fish-shell/fish-shell/releases/tag/4.3.0):

> fish no longer sets [universal variables](https://fishshell.com/docs/4.3/language.html#variables-universal) by default, which simplifies configuration. Specifically, the fish_color_, fish_pager_color_ and fish_key_bindings variables are now set in the global scope by default. After upgrading to 4.3.0, fish will (once and never again) migrate these universals to globals set at startup in the ~/.config/fish/conf.d/fish_frozen_theme.fish and ~/.config/fish/conf.d/fish_frozen_key_bindings.fish files. We suggest that you delete those files and [set your theme](https://fishshell.com/docs/4.3/interactive.html#syntax-highlighting) in ~/.config/fish/config.fish.

This change forwards the fish_keybindings for the prompt as well as does a check if the fish_keybindings is not set.

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux**.
- [x] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
