### PR TITLE
Fix bold leaking from home directory pwd to right prompt

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -12,7 +12,7 @@ eval "function _tide_pwd
             set -f split_output \"$unwritable_icon\$split_pwd[1]\" \$split_pwd[2..]
         set split_output[-1] \"$color_anchors\$split_output[-1]$reset_to_color_dirs\"
     else
-        set -f split_output \"$home_icon$color_anchors~\"
+        set -f split_output \"$home_icon$color_anchors~$reset_to_color_dirs\"
     end
 
     string join / -- \$split_output | string length -V | read -g _tide_pwd_len


### PR DESCRIPTION
## Summary
- When pwd is the home directory (`~`), `set_color -o` (bold) for the anchor 
  directory is not reset, causing bold to leak into all subsequent prompt items 
  (separators, right-side items)
- The non-home code path correctly appends `$reset_to_color_dirs` (line 13) but 
  the home/else branch (line 15) does not

## Reproduction
1. `cd ~`
2. Observe that right-side prompt items (status, time, etc.) render in bold
3. `cd ~/some/path` — right side renders normally (bold is reset)

## Fix
Add `$reset_to_color_dirs` after `~` in the home directory case, matching the 
non-home case behavior.

## Test plan
- [ ] Open new shell in home directory, verify right prompt is not bold
- [ ] Navigate to subdirectory, verify no change in behavior
- [ ] Run `tide configure`, verify fix persists in regenerated function