### PR TITLE
Cleanup jj

### DIFF
--- a/functions/_tide_cache_variables.fish
+++ b/functions/_tide_cache_variables.fish
@@ -2,8 +2,12 @@ function _tide_cache_variables
     # Same-color-separator color
     set_color $tide_prompt_color_separator_same_color | read -gx _tide_color_separator_same_color
 
-    # git
-    contains git $_tide_left_items $_tide_right_items && set_color $tide_git_color_branch | read -gx _tide_location_color
+    # git/jj
+    if contains git $_tide_left_items $_tide_right_items
+        set_color $tide_git_color_branch | read -gx _tide_location_color
+    else if contains jj $_tide_left_items $_tide_right_items
+        set_color $tide_jj_color_branch | read -gx _tide_location_color
+    end
 
     # private_mode
     if contains private_mode $_tide_left_items $_tide_right_items && test -n "$fish_private_mode"

--- a/functions/_tide_item_jj.fish
+++ b/functions/_tide_item_jj.fish
@@ -3,33 +3,27 @@ function _tide_item_jj
         return 1
     end
 
-    set jj_status (jj log -r@ -n1 --no-graph --color always -T '
-    separate(" ",
-        bookmarks.map(|x| if(
-            x.name().substr(0, 10).starts_with(x.name()),
-            x.name().substr(0, 10),
-            x.name().substr(0, 9) ++ "…")
-        ).join(" "),
-        tags.map(|x| if(
-            x.name().substr(0, 10).starts_with(x.name()),
-            x.name().substr(0, 10),
-            x.name().substr(0, 9) ++ "…")
-        ).join(" "),
-        surround("\"","\"",
-            if(
-                description.first_line().substr(0, 24).starts_with(description.first_line()),
-                description.first_line().substr(0, 24),
-                description.first_line().substr(0, 23) ++ "…"
-            )
-        ),
-        change_id.shortest(),
-        commit_id.shortest(),
-        diff.files().len() ++ "m",
-        diff.stat().total_added() ++ "+",
-        diff.stat().total_removed() ++ "-",
-        if(conflict, "conflict"),
-        if(divergent, "divergent"),
-        if(hidden, "hidden"),
-    )' 2> /dev/null | string trim) # send stderr to dev/null so that when prompt re-renders after `jj git init` we don't see an error message
-    _tide_print_item jj $tide_jj_icon' ' (set_color $tide_jj_color; echo -ns "("; echo -ns "$jj_status"; set_color $tide_jj_color; echo -ns ")")
+    jj log -r@ -n1 --no-graph --color never -T '
+        separate("\n",
+            if(bookmarks, bookmarks.map(|x| x.name()).join(" "), change_id.shortest()),
+            if(conflict, "1", "0"),
+            diff.files().len(),
+        )
+    ' 2>/dev/null | read -fL location conflicted modified
+
+    if test "$conflicted" = "1"
+        set -g tide_jj_bg_color $tide_git_bg_color_urgent
+    else if test "$modified" != "0" -a "$modified" != ""
+        set -g tide_jj_bg_color $tide_git_bg_color_unstable
+    end
+
+    _tide_print_item jj $_tide_location_color$tide_jj_icon' ' (
+        echo -ns $location
+        if test "$conflicted" = "1"
+            set_color $tide_git_color_conflicted; echo -ns " ~"
+        end
+        if test "$modified" != "0" -a "$modified" != ""
+            set_color $tide_git_color_dirty; echo -ns " !"$modified
+        end
+    )
 end

--- a/functions/tide/configure/choices/all/icons.fish
+++ b/functions/tide/configure/choices/all/icons.fish
@@ -22,6 +22,7 @@ function _enable_icons
     set -g fake_tide_pwd_icon_home 
     set -g fake_tide_cmd_duration_icon 
     set -g fake_tide_git_icon 
+    set -g fake_tide_jj_icon 
 end
 
 function _disable_icons
@@ -30,4 +31,5 @@ function _disable_icons
     set fake_tide_pwd_icon_home
     set fake_tide_cmd_duration_icon
     set fake_tide_git_icon
+    set fake_tide_jj_icon
 end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -46,7 +46,12 @@ tide_go_bg_color 444444
 tide_go_color 00ACD7
 tide_java_bg_color 444444
 tide_java_color ED8B00
-tide_jj_color green
+tide_jj_bg_color 444444
+tide_jj_bg_color_unstable 444444
+tide_jj_bg_color_urgent 444444
+tide_jj_color white
+tide_jj_color_branch green
+tide_jj_icon ''
 tide_jobs_bg_color 444444
 tide_jobs_color $_tide_color_dark_green
 tide_jobs_number_threshold 1000

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -39,6 +39,9 @@ tide_go_bg_color black
 tide_go_color brcyan
 tide_java_bg_color black
 tide_java_color yellow
+tide_jj_bg_color black
+tide_jj_color green
+tide_jj_icon ''
 tide_jobs_bg_color black
 tide_jobs_color green
 tide_kubectl_bg_color black

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -46,7 +46,12 @@ tide_go_bg_color normal
 tide_go_color 00ACD7
 tide_java_bg_color normal
 tide_java_color ED8B00
-tide_jj_color green
+tide_jj_bg_color normal
+tide_jj_bg_color_unstable normal
+tide_jj_bg_color_urgent normal
+tide_jj_color white
+tide_jj_color_branch green
+tide_jj_icon ''
 tide_jobs_bg_color normal
 tide_jobs_color $_tide_color_dark_green
 tide_jobs_number_threshold 1000

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -39,6 +39,9 @@ tide_go_bg_color normal
 tide_go_color brcyan
 tide_java_bg_color normal
 tide_java_color yellow
+tide_jj_bg_color normal
+tide_jj_color green
+tide_jj_icon ''
 tide_jobs_bg_color normal
 tide_jobs_color green
 tide_kubectl_bg_color normal

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -49,7 +49,12 @@ tide_java_color 000000
 tide_jobs_bg_color 444444
 tide_jobs_color 4E9A06
 tide_jobs_number_threshold 1000
-tide_jj_color green
+tide_jj_bg_color 4E9A06
+tide_jj_bg_color_unstable C4A000
+tide_jj_bg_color_urgent CC0000
+tide_jj_color 000000
+tide_jj_color_branch 000000
+tide_jj_icon ''
 tide_kubectl_bg_color 326CE5
 tide_kubectl_color 000000
 tide_left_prompt_frame_enabled true

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -39,6 +39,9 @@ tide_go_bg_color brcyan
 tide_go_color black
 tide_java_bg_color yellow
 tide_java_color black
+tide_jj_bg_color green
+tide_jj_color black
+tide_jj_icon ''
 tide_jobs_bg_color brblack
 tide_jobs_color green
 tide_kubectl_bg_color blue

--- a/functions/tide/configure/icons.fish
+++ b/functions/tide/configure/icons.fish
@@ -14,6 +14,7 @@ tide_gcloud_icon 󰊭 # Actual google cloud glyph is harder to see
 tide_git_icon
 tide_go_icon 
 tide_java_icon 
+tide_jj_icon
 tide_jobs_icon 
 tide_kubectl_icon 󱃾
 tide_nix_shell_icon 


### PR DESCRIPTION
  Fix and Refactor jj (Jujutsu) Prompt Item

  This PR addresses rendering issues and configuration gaps in the jj (Jujutsu) implementation. Previously, the jj item
  produced cluttered output (raw IDs and status strings) and lacked proper contrast on colored backgrounds.

  Changes
   - Refactored _tide_item_jj.fish: Switched to a minimal, high-signal template that aligns with Tide's git philosophy. It now
     displays the bookmark/short ID and status symbols (~, !) instead of raw logs.
   - Fixed Color Contrast: Removed hardcoded white text. Added tide_jj_color_branch for icon/location coloring and ensured
     tide_jj_color provides high contrast (e.g., Black on Gold in Rainbow mode).
   - Icon Integration: Added tide_jj_icon to the configuration registry and enabled the Nerd Font icon () when the "Many
     icons" style is selected.
   - Improved Stability: Forced --color never in jj calls to prevent ANSI sequence corruption.
   - Standardized Configs: Added missing jj background and color variables to all default styles (Lean, Classic, Rainbow, and
     16-color variants).

  Attribution
  This contribution was researched and implemented by Gemini (via Gemini CLI).

Should address #21 

Note: I don't use jj, but I had previously installed it for testing and I ran into this so I had gemini fix it.  So hopefully this looks okay