### PR TITLE
Migrate build and test workflow from Makefile to mise tasks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
-      - run: make test -C "$GITHUB_WORKSPACE"
+      - uses: jdx/mise-action@v2
+      - run: mise run test
 
   syntax-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,6 @@ jobs:
 
   mega-linter:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: oxsecurity/megalinter/flavors/documentation@v9

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,9 @@ jobs:
 
   mega-linter:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: oxsecurity/megalinter/flavors/documentation@v9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,17 +35,17 @@ Examples:
 - Items begin with `_tide_item_`
 - Subcommands begin with `_tide_sub_`
 
-## Makefile
+## Mise Tasks
 
 Pretty self explanatory.
 
-- `make all`
-- `make fmt`
-- `make lint`
-- `make install`
-- `make test`
+- `mise run all`
+- `mise run fmt`
+- `mise run lint`
+- `mise run install`
+- `mise run test`
 
-In general, just run `make` to do everything.
+In general, just run `mise run all` to do everything.
 
 ### Specifics
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,41 @@
+[tasks.fmt]
+description = 'Format fish files'
+run = 'find . -name "*.fish" -type f -print0 | xargs -0 fish_indent --write'
+
+[tasks.lint]
+description = 'Syntax-check fish files'
+run = 'find . -name "*.fish" -type f -print0 | xargs -0 -n1 fish --no-execute'
+
+[tasks.install]
+description = 'Install Tide and test dependencies via fisher'
+run = '''
+fish -c 'type -q fisher || begin; curl -sL https://git.io/fisher | source; fisher install jorgebucaran/fisher; end'
+fish -c 'fisher install . >/dev/null'
+'''
+
+[tasks.littlecheck]
+description = 'Download littlecheck test runner'
+run = 'curl -sL https://raw.githubusercontent.com/ridiculousfish/littlecheck/HEAD/littlecheck/littlecheck.py -o littlecheck.py'
+
+[tasks.test]
+description = 'Run test suite'
+depends = ['install', 'littlecheck']
+run = '''
+fish -c 'type -q mock || fisher install IlanCosman/clownfish'
+fish tests/test_cleanup.fish
+fish tests/test_setup.fish
+fish -c '_tide_remove_unusable_items'
+fish -c 'begin; _tide_cache_variables; python3 littlecheck.py --progress tests/**.test.fish; set -l test_status $status; fish tests/test_cleanup.fish; exit $test_status; end'
+'''
+
+[tasks.clean]
+description = 'Remove generated test helper'
+run = 'rm -f littlecheck.py'
+
+[tasks.all]
+description = 'Format, lint, install, and test'
+depends = ['fmt', 'lint', 'install', 'test']
+
 [tasks.release]
 confirm = 'Are you sure you want to cut a new release?'
 description = 'Cut a new release'


### PR DESCRIPTION
## Summary
This is PR 1 of the Makefile-to-mise migration.

- Add `mise` task equivalents for `fmt`, `lint`, `install`, `littlecheck`, `test`, `clean`, and `all`
- Update CI to run `mise run test` instead of `make test`
- Update contributor docs to use `mise run ...` commands

## Notes
- `Makefile` is intentionally kept in this PR for compatibility and incremental rollout.
- Follow-up PR can remove or shim `Makefile` once the new workflow has baked.

## Validation
- `mise run lint` passes locally
- `mise run test` reaches the test install path but fails in this local environment because fisher refuses to overwrite an already-installed Tide in `~/.config/fish` (environment-specific conflict)
