### PR TITLE
Add agent guidance for correct PR target repository

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,5 @@
+# Agents
+
+All agent-driven work must be opened as pull requests against `plttn/tide`.
+
+Do not open pull requests against `IlanCosman/tide` (upstream) for work done in this fork.


### PR DESCRIPTION
## Summary
Add agent instructions to ensure work in this fork is opened against `plttn/tide`.

## Changes
- Add `agents.md` with explicit guidance to target `plttn/tide`
- Clarify that `IlanCosman/tide` is upstream and should not receive PRs from this fork's agent-driven work
