### PR TITLE
Stop snapshotting working copy with workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v7.0.15][] (???)
+
+### Bug fixes
+
+- Use `--ignore-working-copy` for JJ workspace detection to avoid snapshotting
+  every prompt redraw.
+
 ## [v7.0.14][] (Apr 18 2026)
 
 ### Bug fixes

--- a/functions/_tide_item_vcs.fish
+++ b/functions/_tide_item_vcs.fish
@@ -145,7 +145,7 @@ if(self.contained_in("::trunk() & ~::@"),
 
                 # Show workspace if multiple workspaces exist
                 set -l workspace_label ""
-                set -l wc_count (jj workspace list --no-pager --color=never 2>/dev/null | count)
+                set -l wc_count (jj workspace list --no-pager --color=never --ignore-working-copy 2>/dev/null | count)
                 if test $wc_count -gt 1; and test -n "$parts[4]"
                     set -l bold_brgreen_color (set_color brgreen)
                     set workspace_label " $bold_brgreen_color$parts[4]$reset"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

We were snapshotting every time. this adds a lot of op logs, not good

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
