### PR TITLE
fix(pwd): only clear glob when contains fails, not unconditionally

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -28,7 +28,7 @@ eval "function _tide_pwd
             string match -qr \"(?<trunc>\..|.)\" \$dir_section
 
             set -l glob \$parent_dir/\$trunc*/
-            set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob)] # This is faster than inverse string match
+            set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob; or echo 1..-1)] # This is faster than inverse string match
 
             while string match -qr \"^\$parent_dir/\$(string escape --style=regex \$trunc)\" \$glob &&
                     string match -qr \"(?<trunc>\$(string escape --style=regex \$trunc).)\" \$dir_section

--- a/tests/_tide_item_pwd.test.fish
+++ b/tests/_tide_item_pwd.test.fish
@@ -130,5 +130,16 @@ mkdir -p "$tmpdir/tmp/[hello"
 _pwd $tmpdir/tmp/$longDirWithDot # CHECK: ~/t/[t/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
 command rm -r "$tmpdir/tmp/[hello"
 
+# ---------- Truncation when an ancestor directory is unreadable ----------
+# Regression test for #11 / #43: an execute-only (no read) ancestor makes the
+# disambiguation glob come back empty. `cd` still works since it only needs +x,
+# but `contains` can't find the current dir in an empty glob, and erasing with
+# that empty result used to crash with "set: --erase: option requires an argument".
+mkdir -p $tmpdir/tmp/noread/$longDir
+chmod 100 $tmpdir/tmp/noread
+_pwd $tmpdir/tmp/noread/$longDir # CHECK: ~/t/n/a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
+chmod 700 $tmpdir/tmp/noread
+command rm -r $tmpdir/tmp/noread
+
 # ------------------------------------Cleanup------------------------------------
 command rm -r $tmpdir


### PR DESCRIPTION
## Summary
- Fixes the crash from #11 (`set: --erase: option requires an argument` in `_tide_pwd`), which happens when an ancestor directory in `$PWD` is execute-only (searchable but not listable) — `cd` succeeds but the disambiguation glob comes back empty, and `contains -i ... $glob` finds nothing.
- Supersedes #12: that PR silenced the crash with `contains ... | echo`, but `echo` doesn't read from stdin, so the substitution is empty **unconditionally**, not just on failure. That erases the entire `$glob` candidate list on every truncation, disabling sibling-directory disambiguation globally (e.g. `foobar` and `foobaz` would both truncate to `f` instead of staying distinguishable). Credit to [faho for catching this](https://github.com/plttn/tide/pull/12#issuecomment-3132534860) on the original PR.
- This version only substitutes a full-range erase (`1..-1`) when `contains` actually fails, preserving the original disambiguation behavior in the success path.

Verified locally (isolated fish repros, not included as a test suite):
- Success-path truncation output is byte-for-byte identical to pristine `main` across unique dirs, hidden dirs, and multi-way ambiguous prefixes.
- The permission-denied repro from #11 (execute-only parent dir) no longer crashes and falls back to a minimal, non-crashing truncation.

Closes #11

## Test plan
- [ ] `cd` into a directory whose path includes an execute-only (non-readable) ancestor, with terminal narrow enough to force truncation — confirm no error is printed.
- [ ] `cd` into two sibling directories sharing a long common prefix (e.g. `foobar`/`foobaz`) with a narrow terminal — confirm each still truncates to a distinguishing prefix rather than collapsing to the same single character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)