### PR TITLE
chore(test): cache local test HOME across runs instead of using mktemp

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,10 @@ description = 'Run test suite'
 depends = ['littlecheck']
 file = 'scripts/test.fish'
 
+[tasks.test-clean]
+description = 'Remove the cached local test HOME used by `mise run test`'
+file = 'scripts/test_clean.fish'
+
 [tasks.clean]
 description = 'Remove generated test helper'
 run = 'rm -f littlecheck.py'

--- a/scripts/test.fish
+++ b/scripts/test.fish
@@ -20,8 +20,14 @@ exit \$test_status
 if test "$GITHUB_ACTIONS" = true #we can just have it work normally in CI, since it runs in a clean environment
     fish -c $inner_cmd
 else
-    set -l test_home (mktemp -d)
+    # Reuse a persistent HOME across local runs (shared across worktrees) so
+    # fisher/clownfish aren't reinstalled over the network every time. `fisher
+    # install .` still runs unconditionally, so local edits are always synced.
+    # Run `mise run test-clean` to wipe it if it ever gets into a bad state.
+    set -l cache_home $XDG_CACHE_HOME
+    test -n "$cache_home" || set cache_home $HOME/.cache
+    set -l test_home $cache_home/tide-test-home
+    mkdir -p $test_home
     env HOME=$test_home XDG_CONFIG_HOME=$test_home/.config fish -c $inner_cmd
-    command rm -rf $test_home
 end
 exit $status

--- a/scripts/test_clean.fish
+++ b/scripts/test_clean.fish
@@ -1,0 +1,12 @@
+#!/usr/bin/env fish
+
+set -l cache_home $XDG_CACHE_HOME
+test -n "$cache_home" || set cache_home $HOME/.cache
+set -l test_home $cache_home/tide-test-home
+
+if test -d $test_home
+    command rm -r $test_home
+    echo "Removed $test_home"
+else
+    echo "Nothing to clean: $test_home does not exist"
+end


### PR DESCRIPTION
## Summary
- `scripts/test.fish` already guards fisher/clownfish installs with `type -q fisher || ...` and `type -q mock || ...`, but the local (non-CI) branch handed those guards a brand-new `mktemp -d` `$HOME` on every run, so they never actually short-circuited — every local `mise run test` re-fetched fisher and clownfish over the network.
- Swap the ephemeral tmpdir for a persistent `${XDG_CACHE_HOME:-$HOME/.cache}/tide-test-home`. It's shared across worktrees of this repo (fisher/clownfish don't vary per checkout), while `fisher install .` still runs unconditionally every time so local edits to `functions/` are always picked up.
- CI is untouched — GitHub Actions already runs each job in a clean container, so the `GITHUB_ACTIONS = true` branch of the script is unchanged.
- Added `mise run test-clean` (backed by `scripts/test_clean.fish`, not an inline `rm -rf` in `mise.toml`) as an escape hatch if the cache ever needs a full reset — it checks existence first and uses `rm -r` rather than `-f`.

Verified locally:
- Cold cache: first `mise run test` bootstraps fisher + clownfish as before, full suite passes.
- Warm cache: second run has zero `Fetching https://api.github.com/...` lines and still passes all 29 test files.
- `mise run test-clean` removes a populated cache, and is a no-op (exit 0) when the cache doesn't exist.

## Test plan
- [ ] `mise run test-clean && mise run test` — confirm cold bootstrap still works
- [ ] `mise run test` again — confirm no fisher/clownfish network fetch and suite still passes
- [ ] `mise run test-clean` twice in a row — confirm second run doesn't error

🤖 Generated with [Claude Code](https://claude.com/claude-code)