### PR TITLE
perf(vcs): reduce git process count in git fallback from 5 to 3

### DIFF
--- a/functions/_tide_item_vcs.fish
+++ b/functions/_tide_item_vcs.fish
@@ -217,18 +217,10 @@ if(self.contained_in("::trunk() & ~::@"),
         return
     end
 
-    if git branch --show-current 2>/dev/null | string shorten -"$tide_git_truncation_strategy"m$tide_git_truncation_length | read -l location
-        git rev-parse --git-dir --is-inside-git-dir | read -fL gdir in_gdir
-        set location $_tide_location_color$location
-    else if test $pipestatus[1] != 0
-        return
-    else if git tag --points-at HEAD | string shorten -"$tide_git_truncation_strategy"m$tide_git_truncation_length | read location
-        git rev-parse --git-dir --is-inside-git-dir | read -fL gdir in_gdir
-        set location '#'$_tide_location_color$location
-    else
-        git rev-parse --git-dir --is-inside-git-dir --short HEAD | read -fL gdir in_gdir location
-        set location @$_tide_location_color$location
-    end
+    # Reduces the git process count for this item from 5 to 3.
+    # Ported from https://github.com/IlanCosman/tide/pull/663 by @lgeiger.
+    git rev-parse --git-dir --is-inside-git-dir 2>/dev/null | read -fL gdir in_gdir
+    or return
 
     # Operation
     if test -d $gdir/rebase-merge
@@ -262,16 +254,40 @@ if(self.contained_in("::trunk() & ~::@"),
 
     # Git status/stash + Upstream behind/ahead
     test $in_gdir = true && set -l _set_dir_opt -C $gdir/..
-    # Suppress errors in case we are in a bare repo or there is no upstream
-    set -l stat (git $_set_dir_opt --no-optional-locks status --porcelain 2>/dev/null)
-    string match -qr '(0|(?<stash>.*))\n(0|(?<conflicted>.*))\n(0|(?<staged>.*))
-(0|(?<dirty>.*))\n(0|(?<untracked>.*))(\n(0|(?<behind>.*))\t(0|(?<ahead>.*)))?' \
-        "$(git $_set_dir_opt stash list 2>/dev/null | count
-        string match -r ^UU $stat | count
-        string match -r ^[ADMR] $stat | count
-        string match -r ^.[ADMR] $stat | count
-        string match -r '^\?\?' $stat | count
-        git rev-list --count --left-right @{upstream}...HEAD 2>/dev/null)"
+    set -l stat (git $_set_dir_opt --no-optional-locks status --porcelain --branch 2>/dev/null)
+
+    set -l location
+    set -l ahead (string match -r '(?<=ahead )\d+' $stat[1])
+    set -l behind (string match -r '(?<=behind )\d+' $stat[1])
+
+    set -l conflicted (count (string match -r '^UU' $stat[2..]))
+    set -l staged (count (string match -r '^[ADMR]' $stat[2..]))
+    set -l dirty (count (string match -r '^.[ADMR]' $stat[2..]))
+    set -l untracked (count (string match -r '^\?\?' $stat[2..]))
+
+    # Get location
+    set -l branch (string split '...' $stat[1])[1]
+    set branch (string replace -r '^## (?:No commits yet on )?' '' $branch)
+
+    if test -n "$branch" -a "$branch" != "HEAD (no branch)"
+        set location (echo -ns $branch | string shorten -"$tide_git_truncation_strategy"m$tide_git_truncation_length)
+        set location $_tide_location_color$location
+    else if git branch --show-current 2>/dev/null | string shorten -"$tide_git_truncation_strategy"m$tide_git_truncation_length | read -f location
+        set location $_tide_location_color$location
+    else if git tag --points-at HEAD 2>/dev/null | string shorten -"$tide_git_truncation_strategy"m$tide_git_truncation_length | read location
+        set location '#'$_tide_location_color$location
+    else
+        git rev-parse --short HEAD 2>/dev/null | read -f location
+        set location @$_tide_location_color$location
+    end
+
+    set -l stash (git $_set_dir_opt stash list 2>/dev/null | count)
+
+    test "$stash" = 0 && set -e stash
+    test "$conflicted" = 0 && set -e conflicted
+    test "$staged" = 0 && set -e staged
+    test "$dirty" = 0 && set -e dirty
+    test "$untracked" = 0 && set -e untracked
 
     if test -n "$operation$conflicted"
         set -g tide_git_bg_color $tide_git_bg_color_urgent

--- a/tests/_tide_item_vcs.test.fish
+++ b/tests/_tide_item_vcs.test.fish
@@ -99,7 +99,7 @@ _vcs_item # CHECK: 10charhere ?1
 cd $dir/massive-status-repo
 _git init
 _git branch -m main
-mock git "--no-optional-locks status --porcelain" "string repeat -n100000 'D  some-file-name'\n"
+mock git "--no-optional-locks status --porcelain --branch" "echo '## main'; string repeat -n100000 'D  some-file-name'\n"
 _vcs_item # CHECK: main +100000
 
 # -------- jj repo tests --------


### PR DESCRIPTION
## Summary
Ports the git-subprocess-reduction optimization from [IlanCosman/tide#663](https://github.com/IlanCosman/tide/pull/663) (by [@lgeiger](https://github.com/lgeiger), still open upstream) into this fork's git fallback path in `functions/_tide_item_vcs.fish`.

When git/jj got unified into `_tide_item_vcs` (`v7.0.13`), the git-handling logic was carried over verbatim from the old pre-#663 `_tide_item_git.fish` — 5 git processes per render (`git branch --show-current`, `git rev-parse --git-dir --is-inside-git-dir`, `git status --porcelain`, `git stash list`, `git rev-list --count --left-right @{upstream}...HEAD`). This never got the upstream fix since that PR hasn't merged.

Adding `--branch` to `git status --porcelain` puts a header line first in the output (e.g. `## main...origin/main [ahead 2, behind 1]`) that already contains the branch name and ahead/behind counts, eliminating two of the five calls:
- Branch name is now parsed from that header (falling back to the old branch/tag/detached-HEAD cascade only when the header doesn't yield a usable name, e.g. detached HEAD)
- Ahead/behind come from a regex lookbehind on the same header instead of a separate `git rev-list` call
- `git stash list` stays, since `git status` can't report stash count

Result: 3 git processes instead of 5, same observable output. Only the git fallback path is touched — the jj path (`_tide_internal_jj_git`) is untouched.

## Test plan
- [x] `mise run lint` / `fish_indent --check` pass
- [x] `mise run test` — full suite passes, including `_tide_item_vcs.test.fish` (branch names, detached HEAD, tags, ahead/behind, stash, staged/dirty/untracked, submodules, massive-status-repo)
- [x] Updated the massive-status-repo test fixture to mock `--branch` and return a synthetic `## main` header line, matching upstream's own test update in #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)