### PR TITLE
fix: always isolate test runs from the real fish HOME

### DIFF
--- a/scripts/test.fish
+++ b/scripts/test.fish
@@ -17,8 +17,15 @@ fish tests/test_cleanup.fish
 exit \$test_status
 "
 
-if test "$GITHUB_ACTIONS" = true #we can just have it work normally in CI, since it runs in a clean environment
-    fish -c $inner_cmd
+# Always run against an isolated HOME so tests can never write into the real
+# fish config -- even if GITHUB_ACTIONS happens to be set in a local shell
+# (this previously ran the "normal" branch below unguarded and clobbered a
+# real ~/.config/fish/fish_variables).
+if test "$GITHUB_ACTIONS" = true
+    # CI runners are already fresh/ephemeral, so there's nothing worth
+    # caching across runs -- a throwaway dir is enough.
+    set -l test_home (mktemp -d)
+    env HOME=$test_home XDG_CONFIG_HOME=$test_home/.config fish -c $inner_cmd
 else
     # Reuse a persistent HOME across local runs (shared across worktrees) so
     # fisher/clownfish aren't reinstalled over the network every time. `fisher


### PR DESCRIPTION
#### Description

`scripts/test.fish` only overrode `HOME`/`XDG_CONFIG_HOME` in the non-CI branch, trusting `$GITHUB_ACTIONS` to gate whether isolation was needed. If that variable is ever set in a local shell for any other reason, `mise run test` silently runs fisher installs, `funcsave`, and test uvar writes directly against the real `~/.config/fish`.

Always run against an isolated HOME now: a throwaway `mktemp -d` in CI (already an ephemeral runner, so nothing worth caching) and the existing cached test-home locally, with no path that skips isolation.

#### Motivation and Context

This is exactly what happened while working on the other two PRs in this sequence — a local run clobbered real `tide_left_prompt_items`/frame settings and left stray `mock.fish`/`_tide_decolor.fish` files behind in `~/.config/fish`. Not tied to a filed issue; found and fixed in the process.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

Ran the full suite (`mise run test`) against a freshly-wiped test-home under both the local-cache path and a simulated-CI path (`GITHUB_ACTIONS=true`); confirmed via `stat` that `~/.config/fish/fish_variables`/`fish_plugins` mtimes didn't move during either run.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)