### PR TITLE
fix: clean up orphaned _tide_prompt_* uvars on update

### DIFF
--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -37,6 +37,7 @@ function _tide_init_update --on-event _tide_init_update
     set -q tide_jobs_number_threshold || set -U tide_jobs_number_threshold 1000
 
     _tide_migrate_vcs_prompt_items
+    _tide_migrate_orphaned_prompt_vars
 end
 
 function _tide_init_uninstall --on-event _tide_init_uninstall

--- a/functions/_tide_migrate_orphaned_prompt_vars.fish
+++ b/functions/_tide_migrate_orphaned_prompt_vars.fish
@@ -1,0 +1,12 @@
+function _tide_migrate_orphaned_prompt_vars
+    for name in (set -U --names | string match -r '^_tide_prompt_\d+$')
+        set -l pid (string replace -r '^_tide_prompt_' '' -- $name)
+
+        test "$pid" = "$fish_pid" && continue
+        # A live PID that no longer belongs to us (EPERM) means our shell already
+        # exited, so treat that the same as ESRCH: the var is orphaned either way.
+        command kill -0 $pid 2>/dev/null && continue
+
+        set -e $name
+    end
+end

--- a/tests/_tide_migrate_orphaned_prompt_vars.test.fish
+++ b/tests/_tide_migrate_orphaned_prompt_vars.test.fish
@@ -1,0 +1,16 @@
+# RUN: %fish %s
+set -l dead_pid (fish -c 'echo $fish_pid')
+
+set -U _tide_prompt_$dead_pid ''
+set -U _tide_prompt_$fish_pid ''
+set -U _tide_prompt_notanumber ''
+set -U some_other_var_$dead_pid ''
+
+_tide_migrate_orphaned_prompt_vars
+
+set -U --names | string match _tide_prompt_$dead_pid | count # CHECK: 0
+set -U --names | string match _tide_prompt_$fish_pid | count # CHECK: 1
+set -U --names | string match _tide_prompt_notanumber | count # CHECK: 1
+set -U --names | string match some_other_var_$dead_pid | count # CHECK: 1
+
+set -e _tide_prompt_$fish_pid _tide_prompt_notanumber some_other_var_$dead_pid


### PR DESCRIPTION
#### Description

Fish only fires `fish_exit` handlers on a clean shell exit, so a shell killed by SIGHUP/crash (closing a terminal, `tmux kill-server`, etc.) never runs `_tide_on_fish_exit`, leaving its `_tide_prompt_$fish_pid` universal variable behind forever. Sweeps and removes any such uvar whose PID is no longer alive, on every `fisher update`, matching the existing `_tide_migrate_vcs_prompt_items` pattern.

#### Motivation and Context

Related to #51 and [IlanCosman/tide#636](https://github.com/IlanCosman/tide/issues/636) (upstream).

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

New littlecheck test (`tests/_tide_migrate_orphaned_prompt_vars.test.fish`) seeding a genuinely-dead PID, the current shell's own live var, a malformed name, and an unrelated var — only the dead one gets erased. Full suite passes.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)