### PR TITLE
perf(prompt): replace per-render uvar handoff with tmpfile + signal

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -8,7 +8,8 @@ _tide_parent_dirs
 source (functions --details _tide_pwd)
 
 set -l prompt_var _tide_prompt_$fish_pid
-set -U $prompt_var # Set var here so if we erase $prompt_var, bg job won't set a uvar
+set -g $prompt_var
+set -l prompt_tmpfile (mktemp)
 
 set_color normal | read -l color_normal
 status fish-path | read -l fish_path
@@ -18,10 +19,22 @@ if string match -i homebrew/Cellar $fish_path
 end
 
 # _tide_repaint prevents us from creating a second background job
-function _tide_refresh_prompt --on-variable $prompt_var --on-variable COLUMNS
+function _tide_refresh_prompt --on-signal SIGUSR1 --on-variable COLUMNS --inherit-variable prompt_var --inherit-variable prompt_tmpfile
+    set -g $prompt_var (cat $prompt_tmpfile 2>/dev/null)
     set -g _tide_repaint
     commandline -f repaint
 end
+
+# Escape hatch: some sandboxes/containers block or silently swallow signal
+# delivery. Self-signal once at init (on a signal SIGUSR1 never uses) so we
+# know, before the first render, whether SIGUSR1 can actually reach us --
+# if not, every render below falls back to rendering synchronously instead
+# of spawning a background job that can never notify us it's done.
+function _tide_signal_test --on-signal SIGUSR2
+    set -g _tide_signal_confirmed true
+    functions -e _tide_signal_test
+end
+command kill -s USR2 $fish_pid 2>/dev/null; or set -g _tide_signal_unavailable true
 
 if contains newline $_tide_left_items # two line prompt initialization
     test "$tide_prompt_add_newline_before" = true && set -l add_newline '\n'
@@ -41,14 +54,27 @@ if contains newline $_tide_left_items # two line prompt initialization
     eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && jobs -p | count | read -lx _tide_jobs
-        $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
+        if test \"\$_tide_signal_unavailable\" = true
+            set -g $prompt_var (_tide_2_line_prompt)
+        else
+            jobs -q && jobs -p | count | read -lx _tide_jobs
+            $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_2_line_prompt)\" &
-        builtin disown
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode _tide_2_line_prompt >$prompt_tmpfile
+command kill -s USR1 $fish_pid 2>/dev/null\" &
+            builtin disown
 
-        command kill \$_tide_last_pid 2>/dev/null
-        set -g _tide_last_pid \$last_pid
+            command kill \$_tide_last_pid 2>/dev/null
+            set -g _tide_last_pid \$last_pid
+
+            if not set -q _tide_signal_confirmed
+                for _tide_i in (seq 1 10)
+                    set -q _tide_signal_confirmed && break
+                    sleep 0.01
+                end
+                set -q _tide_signal_confirmed || set -g _tide_signal_unavailable true
+            end
+        end
     end
 
 
@@ -79,14 +105,27 @@ else # one line prompt initialization
 function fish_prompt
     set -lx _tide_status \$status
     _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        jobs -q && jobs -p | count | read -lx _tide_jobs
-        $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
+        if test \"\$_tide_signal_unavailable\" = true
+            set -g $prompt_var (_tide_1_line_prompt)
+        else
+            jobs -q && jobs -p | count | read -lx _tide_jobs
+            $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
 set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode set $prompt_var (_tide_1_line_prompt)\" &
-        builtin disown
+PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode _tide_1_line_prompt >$prompt_tmpfile
+command kill -s USR1 $fish_pid 2>/dev/null\" &
+            builtin disown
 
-        command kill \$_tide_last_pid 2>/dev/null
-        set -g _tide_last_pid \$last_pid
+            command kill \$_tide_last_pid 2>/dev/null
+            set -g _tide_last_pid \$last_pid
+
+            if not set -q _tide_signal_confirmed
+                for _tide_i in (seq 1 10)
+                    set -q _tide_signal_confirmed && break
+                    sleep 0.01
+                end
+                set -q _tide_signal_confirmed || set -g _tide_signal_unavailable true
+            end
+        end
     end
 
     if contains -- --final-rendering \$argv
@@ -108,6 +147,6 @@ end"
 end
 
 # Inheriting instead of evaling because here load time is more important than runtime
-function _tide_on_fish_exit --on-event fish_exit --inherit-variable prompt_var
-    set -e $prompt_var
+function _tide_on_fish_exit --on-event fish_exit --inherit-variable prompt_tmpfile
+    rm -f $prompt_tmpfile
 end

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -1,0 +1,38 @@
+# RUN: %fish %s
+set -U tide_left_prompt_items status
+set -U tide_right_prompt_items
+set -U tide_prompt_add_newline_before false
+set -U tide_left_prompt_frame_enabled false
+set -U tide_right_prompt_frame_enabled false
+set -U tide_prompt_min_cols 1
+set -Ux tide_status_icon ✔
+set -Ux tide_status_icon_failure ✘
+set -gx COLUMNS 80
+set -gx LINES 24
+
+fish -i -c '
+    false
+    fish_prompt >/dev/null
+    for i in (seq 1 50)
+        set -q _tide_repaint && break
+        sleep 0.01
+    end
+    _tide_decolor (fish_prompt)
+' </dev/null # CHECK: {{.*}}✘ 1{{.*}}
+
+# Signal-unavailable fallback: a fake `kill` that always fails simulates a
+# sandbox that blocks signal delivery. `command kill` bypasses fish
+# functions (by design, same as the real code), so this has to be a real
+# executable ahead of the real one on PATH, not a mocked fish function.
+set -l fake_bin (mktemp -d)
+echo '#!/bin/sh
+exit 1' >$fake_bin/kill
+chmod +x $fake_bin/kill
+
+env PATH="$fake_bin:$PATH" fish -i -c '
+    false
+    _tide_decolor (fish_prompt)
+' </dev/null # CHECK: {{.*}}✘ 1{{.*}}
+
+command rm -r $fake_bin
+set -e tide_left_prompt_items tide_right_prompt_items tide_prompt_add_newline_before tide_left_prompt_frame_enabled tide_right_prompt_frame_enabled tide_prompt_min_cols


### PR DESCRIPTION
#### Description

The background job that computes each prompt render handed its result back to the interactive shell via `set -U $prompt_var`, a universal variable. Every `set -U` rewrites and fsyncs fish's *entire* uvar table (not just the ~1KB prompt string) and broadcasts a change notification to every other open fish shell, which each wake up and reparse the whole `fish_variables` file — on every single prompt render.

Replaces it with a plain per-shell `mktemp` tmpfile the background job writes to, plus a `SIGUSR1` signal to notify the parent to read it and repaint.

Since some sandboxes/containers block or silently swallow signals, adds a layered escape hatch: a near-zero-cost `SIGUSR2` self-test at init, a bounded backstop on the first render only, and a permanent downgrade to synchronous (no background job) rendering for the rest of the session if signals are ever confirmed unavailable — trading async performance for correctness rather than leaving the prompt permanently blank.

#### Motivation and Context

Related to #51 — tide's contribution to the fish-core leftover-temp-file race (fish's own non-atomic uvar rewrite-on-kill) is removed, though the underlying fish-core race itself isn't (that would need a fix in fish-shell/fish-shell, not this repo). Not marking this as "Closes #51" for that reason. Also structurally fixes [IlanCosman/tide#562](https://github.com/IlanCosman/tide/issues/562) — no more per-render `fish_variables` writes at all, for any shell.

Builds on #53 (orphaned uvar cleanup) but is independent and separately revertible — this touches the untested hot path exercised on every keystroke, so keeping it as its own PR keeps the blast radius and revert path isolated from the lower-risk cleanup fix.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

New `tests/fish_prompt.test.fish` (happy-path signal render + mocked-`kill` synchronous fallback). Full suite passes. Manual verification: zero `_tide_prompt_*` uvars created before/after a session, clean tmpfile removal on normal exit, and a simulated SIGHUP left exactly one harmless tmp file behind with `fish_variables` mtime completely unchanged.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)