### PR TITLE
ci: use PAT for release-please so its PR triggers CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   update-floating-tags:
     needs: release-please


### PR DESCRIPTION
#### Description

The default `GITHUB_TOKEN`-authored release-please PR gets held for manual "approve and run" on every check — hit this on #55. GitHub treats `github-actions[bot]`-authored content with extra scrutiny for workflow-run approval, independent of whether the PR is from a fork.

Wires the release-please step to use the `RELEASE_PLEASE_TOKEN` PAT, which already exists as a repo secret (created alongside an earlier, never-merged attempt at this same fix — this just actually wires it into the workflow on `main`). With a PAT, the release PR appears authored by a real account with existing write access, so its checks run normally without the approval gate.

#### Motivation and Context

Fixes the "workflow requires approval" block encountered on #55.

#### How Has This Been Tested

- [x] I have tested using **MacOS** (`actionlint` clean; will confirm the approval gate is actually gone on the next release-please PR after merge).
- [ ] I have tested using **Linux**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)