### PR TITLE
refactor(prompt): dedupe signal-dispatch logic into one function

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -34,7 +34,35 @@ function _tide_signal_test --on-signal SIGUSR2
     set -g _tide_signal_confirmed true
     functions -e _tide_signal_test
 end
-command kill -s USR2 $fish_pid 2>/dev/null; or set -g _tide_signal_unavailable true
+command kill -s USR2 $fish_pid 2>/dev/null || set -g _tide_signal_unavailable true
+
+# Renders in the background (or synchronously, if signals are confirmed
+# unavailable) and repaints when ready. $argv[1] is the render function to
+# call for this session (_tide_1_line_prompt or _tide_2_line_prompt).
+function _tide_dispatch_render --inherit-variable prompt_var --inherit-variable prompt_tmpfile --inherit-variable fish_path
+    if test "$_tide_signal_unavailable" = true
+        set -g $prompt_var ($argv[1])
+        return
+    end
+
+    jobs -q && jobs -p | count | read -lx _tide_jobs
+    $fish_path -c "set _tide_pipestatus $_tide_pipestatus
+set _tide_parent_dirs $_tide_parent_dirs
+PATH="(string escape "$PATH")" CMD_DURATION=$CMD_DURATION fish_key_bindings=$fish_key_bindings fish_bind_mode=$fish_bind_mode $argv[1] >$prompt_tmpfile
+command kill -s USR1 $fish_pid 2>/dev/null" &
+    builtin disown
+
+    command kill $_tide_last_pid 2>/dev/null
+    set -g _tide_last_pid $last_pid
+
+    if not set -q _tide_signal_confirmed
+        for _tide_i in (seq 1 10)
+            set -q _tide_signal_confirmed && break
+            sleep 0.01
+        end
+        set -q _tide_signal_confirmed || set -g _tide_signal_unavailable true
+    end
+end
 
 if contains newline $_tide_left_items # two line prompt initialization
     test "$tide_prompt_add_newline_before" = true && set -l add_newline '\n'
@@ -54,27 +82,7 @@ if contains newline $_tide_left_items # two line prompt initialization
     eval "
 function fish_prompt
     _tide_status=\$status _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        if test \"\$_tide_signal_unavailable\" = true
-            set -g $prompt_var (_tide_2_line_prompt)
-        else
-            jobs -q && jobs -p | count | read -lx _tide_jobs
-            $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
-set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode _tide_2_line_prompt >$prompt_tmpfile
-command kill -s USR1 $fish_pid 2>/dev/null\" &
-            builtin disown
-
-            command kill \$_tide_last_pid 2>/dev/null
-            set -g _tide_last_pid \$last_pid
-
-            if not set -q _tide_signal_confirmed
-                for _tide_i in (seq 1 10)
-                    set -q _tide_signal_confirmed && break
-                    sleep 0.01
-                end
-                set -q _tide_signal_confirmed || set -g _tide_signal_unavailable true
-            end
-        end
+        _tide_dispatch_render _tide_2_line_prompt
     end
 
 
@@ -105,27 +113,7 @@ else # one line prompt initialization
 function fish_prompt
     set -lx _tide_status \$status
     _tide_pipestatus=\$pipestatus if not set -e _tide_repaint
-        if test \"\$_tide_signal_unavailable\" = true
-            set -g $prompt_var (_tide_1_line_prompt)
-        else
-            jobs -q && jobs -p | count | read -lx _tide_jobs
-            $fish_path -c \"set _tide_pipestatus \$_tide_pipestatus
-set _tide_parent_dirs \$_tide_parent_dirs
-PATH=\$(string escape \"\$PATH\") CMD_DURATION=\$CMD_DURATION fish_key_bindings=\$fish_key_bindings fish_bind_mode=\$fish_bind_mode _tide_1_line_prompt >$prompt_tmpfile
-command kill -s USR1 $fish_pid 2>/dev/null\" &
-            builtin disown
-
-            command kill \$_tide_last_pid 2>/dev/null
-            set -g _tide_last_pid \$last_pid
-
-            if not set -q _tide_signal_confirmed
-                for _tide_i in (seq 1 10)
-                    set -q _tide_signal_confirmed && break
-                    sleep 0.01
-                end
-                set -q _tide_signal_confirmed || set -g _tide_signal_unavailable true
-            end
-        end
+        _tide_dispatch_render _tide_1_line_prompt
     end
 
     if contains -- --final-rendering \$argv


### PR DESCRIPTION
#### Description

Stacked on #54. That PR introduced an escape-hatch/dispatch block (signal-availability check, background job launch, debounce, bounded backstop poll) that was duplicated verbatim between the one-line and two-line `eval`'d `fish_prompt` definitions in `functions/fish_prompt.fish`.

This factors it into a single real function, `_tide_dispatch_render`, defined once via `--inherit-variable` and called with one argument (which render function to use) from each branch. Because it's a real function body instead of text templated through `eval`, the PATH-escaping collapses from `\$(string escape \"\$PATH\")` to a plain `(string escape "$PATH")` — the backslashes only existed to survive the outer `eval` step, which no longer applies here. Also fixes an `; or` that should have been `||` per project convention (caught in review of #54).

Pure refactor — no behavior change.

#### Motivation and Context

Found during review of #54: the duplicated block risked the two prompt modes drifting out of sync on a future edit, and was hard to read through the nested escaping.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

- `mise run lint` clean across the repo; `fish_indent` reports no formatting diff.
- Verified in isolated scratch scripts (not committed) that command-scoped prefix assignments (`var=val cmd`) still propagate into the new called function, and that `(string escape "$PATH")` produces an identical value to the original `$(string escape "$PATH")`.
- Full `mise run test` suite passes, including both cases in `tests/fish_prompt.test.fish` (happy-path signal render, mocked-`kill` synchronous fallback) — added by #54, unmodified here.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly. (no test changes needed — pure refactor, existing #54 tests cover behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)