### PR TITLE
fix(prompt): repaint-on-resize, jobs in sync fallback, tmpfile reuse + atomic writes

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -9,7 +9,7 @@ source (functions --details _tide_pwd)
 
 set -l prompt_var _tide_prompt_$fish_pid
 set -g $prompt_var
-set -l prompt_tmpfile (mktemp)
+set -q _tide_prompt_tmpfile || set -g _tide_prompt_tmpfile (mktemp) # global so `tide reload` reuses it instead of leaking one per reload
 
 set_color normal | read -l color_normal
 status fish-path | read -l fish_path
@@ -19,8 +19,16 @@ if string match -i homebrew/Cellar $fish_path
 end
 
 # _tide_repaint prevents us from creating a second background job
-function _tide_refresh_prompt --on-signal SIGUSR1 --on-variable COLUMNS --inherit-variable prompt_var --inherit-variable prompt_tmpfile
-    set -g $prompt_var (cat $prompt_tmpfile 2>/dev/null)
+function _tide_refresh_prompt --on-signal SIGUSR1 --inherit-variable prompt_var
+    set -g $prompt_var (cat $_tide_prompt_tmpfile 2>/dev/null)
+    set -g _tide_repaint
+    commandline -f repaint
+end
+
+# On resize, repaint with the last completed render but leave $prompt_var
+# alone -- in synchronous-fallback mode the tmpfile is never written, so
+# reading it here would blank the prompt.
+function _tide_repaint_on_resize --on-variable COLUMNS
     set -g _tide_repaint
     commandline -f repaint
 end
@@ -39,20 +47,30 @@ command kill -s USR2 $fish_pid 2>/dev/null || set -g _tide_signal_unavailable tr
 # Renders in the background (or synchronously, if signals are confirmed
 # unavailable) and repaints when ready. $argv[1] is the render function to
 # call for this session (_tide_1_line_prompt or _tide_2_line_prompt).
-function _tide_dispatch_render --inherit-variable prompt_var --inherit-variable prompt_tmpfile --inherit-variable fish_path
+function _tide_dispatch_render --inherit-variable prompt_var --inherit-variable fish_path
+    jobs -q && jobs -p | count | read -lx _tide_jobs
+
     if test "$_tide_signal_unavailable" = true
         set -g $prompt_var ($argv[1])
         return
     end
 
-    jobs -q && jobs -p | count | read -lx _tide_jobs
+    # The job renders into a private scratch file (suffixed with its own
+    # pid) and atomically renames it over the shared tmpfile, so the
+    # SIGUSR1 handler can never read a partial write from a newer job. The
+    # tmpfile path crosses into the job string-escaped and is expanded as a
+    # variable there, never re-parsed as syntax, so any TMPDIR is safe.
     $fish_path -c "set _tide_pipestatus $_tide_pipestatus
 set _tide_parent_dirs $_tide_parent_dirs
-PATH="(string escape "$PATH")" CMD_DURATION=$CMD_DURATION fish_key_bindings=$fish_key_bindings fish_bind_mode=$fish_bind_mode $argv[1] >$prompt_tmpfile
+set _tide_prompt_tmpfile "(string escape -- $_tide_prompt_tmpfile)"
+PATH="(string escape "$PATH")" CMD_DURATION=$CMD_DURATION fish_key_bindings=$fish_key_bindings fish_bind_mode=$fish_bind_mode $argv[1] >\$_tide_prompt_tmpfile.\$fish_pid
+command mv -f \$_tide_prompt_tmpfile.\$fish_pid \$_tide_prompt_tmpfile
 command kill -s USR1 $fish_pid 2>/dev/null" &
     builtin disown
 
-    command kill $_tide_last_pid 2>/dev/null
+    # A job killed mid-render leaves its scratch file behind; its pid is
+    # the scratch suffix, so remove it only when the kill actually landed
+    command kill $_tide_last_pid 2>/dev/null && command rm -f $_tide_prompt_tmpfile.$_tide_last_pid
     set -g _tide_last_pid $last_pid
 
     if not set -q _tide_signal_confirmed
@@ -134,7 +152,6 @@ end"
 
 end
 
-# Inheriting instead of evaling because here load time is more important than runtime
-function _tide_on_fish_exit --on-event fish_exit --inherit-variable prompt_tmpfile
-    rm -f $prompt_tmpfile
+function _tide_on_fish_exit --on-event fish_exit
+    rm -f $_tide_prompt_tmpfile $_tide_prompt_tmpfile.$_tide_last_pid
 end

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -1,5 +1,5 @@
 # RUN: %fish %s
-set -U tide_left_prompt_items status
+set -U tide_left_prompt_items status jobs
 set -U tide_right_prompt_items
 set -U tide_prompt_add_newline_before false
 set -U tide_left_prompt_frame_enabled false
@@ -7,9 +7,13 @@ set -U tide_right_prompt_frame_enabled false
 set -U tide_prompt_min_cols 1
 set -Ux tide_status_icon ✔
 set -Ux tide_status_icon_failure ✘
+set -Ux tide_jobs_icon JOBS
+set -Ux tide_jobs_number_threshold 1000
 set -gx COLUMNS 80
 set -gx LINES 24
 
+# Happy path: async render via SIGUSR1, then a resize event must repaint
+# with the same content instead of blanking or recomputing.
 fish -i -c '
     false
     fish_prompt >/dev/null
@@ -18,21 +22,69 @@ fish -i -c '
         sleep 0.01
     end
     _tide_decolor (fish_prompt)
-' </dev/null # CHECK: {{.*}}✘ 1{{.*}}
+    _tide_repaint_on_resize
+    true
+    _tide_decolor (fish_prompt)
+' </dev/null
+# CHECK: {{.*}}✘ 1{{.*}}
+# CHECK: {{.*}}✘ 1{{.*}}
 
 # Signal-unavailable fallback: a fake `kill` that always fails simulates a
 # sandbox that blocks signal delivery. `command kill` bypasses fish
 # functions (by design, same as the real code), so this has to be a real
 # executable ahead of the real one on PATH, not a mocked fish function.
+# With a background job running, the jobs item must render in the
+# synchronous path too, and a resize event must not blank the prompt (the
+# tmpfile is never written in this mode).
 set -l fake_bin (mktemp -d)
 echo '#!/bin/sh
 exit 1' >$fake_bin/kill
 chmod +x $fake_bin/kill
 
 env PATH="$fake_bin:$PATH" fish -i -c '
+    sleep 2 &
     false
     _tide_decolor (fish_prompt)
-' </dev/null # CHECK: {{.*}}✘ 1{{.*}}
+    _tide_repaint_on_resize
+    true
+    _tide_decolor (fish_prompt)
+    wait
+' </dev/null
+# CHECK: {{.*}}✘ 1{{.*}}JOBS{{.*}}
+# CHECK: {{.*}}✘ 1{{.*}}JOBS{{.*}}
 
-command rm -r $fake_bin
-set -e tide_left_prompt_items tide_right_prompt_items tide_prompt_add_newline_before tide_left_prompt_frame_enabled tide_right_prompt_frame_enabled tide_prompt_min_cols
+# Tmpfile hygiene: a fake `mktemp` redirects the prompt tmpfile into a
+# watch dir whose path contains a space, proving the path survives the
+# background job's command string unmangled. macOS mktemp ignores TMPDIR,
+# so PATH-shadowing is the only reliable redirection. After a completed
+# render the scratch file must be renamed away (1 file), `tide reload`
+# must reuse the same tmpfile instead of minting new ones (still 1), and
+# exit must remove it (0).
+set -l watch_root (mktemp -d)
+mkdir -p "$watch_root/tide tmp"
+set -l fake_mktemp_bin (mktemp -d)
+echo '#!/bin/sh
+exec /usr/bin/mktemp "$TIDE_TEST_TMPDIR/tide.XXXXXX"' >$fake_mktemp_bin/mktemp
+chmod +x $fake_mktemp_bin/mktemp
+
+env TIDE_TEST_TMPDIR="$watch_root/tide tmp" PATH="$fake_mktemp_bin:$PATH" fish -i -c '
+    false
+    fish_prompt >/dev/null
+    for i in (seq 1 50)
+        set -q _tide_repaint && break
+        sleep 0.01
+    end
+    _tide_decolor (fish_prompt)
+    echo files-after-render (command ls "$TIDE_TEST_TMPDIR" | count)
+    tide reload
+    tide reload
+    echo files-after-reloads (command ls "$TIDE_TEST_TMPDIR" | count)
+' </dev/null
+# CHECK: {{.*}}✘ 1{{.*}}
+# CHECK: files-after-render 1
+# CHECK: files-after-reloads 1
+echo files-after-exit (command ls "$watch_root/tide tmp" | count)
+# CHECK: files-after-exit 0
+
+command rm -r $fake_bin $fake_mktemp_bin $watch_root
+set -e tide_left_prompt_items tide_right_prompt_items tide_prompt_add_newline_before tide_left_prompt_frame_enabled tide_right_prompt_frame_enabled tide_prompt_min_cols tide_status_icon tide_status_icon_failure tide_jobs_icon tide_jobs_number_threshold


### PR DESCRIPTION
#### Description

Hardens the tmpfile + SIGUSR1 handoff from #54, fixing three confirmed defects and two robustness gaps found in a deep review:

1. **Resize blanked the prompt in signal-unavailable fallback mode.** The combined SIGUSR1/COLUMNS handler unconditionally re-read the tmpfile, which is never written in fallback mode. Resize (`_tide_repaint_on_resize`) now only repaints; only SIGUSR1 reads the tmpfile.
2. **Jobs item disappeared in fallback mode** — the synchronous branch never set `_tide_jobs`. The count is now hoisted above the sync branch.
3. **`tide reload` leaked one tmpfile per invocation** (and `tide configure` reloads on finish). The path now lives in a global reused across re-sourcing.
4. **Torn reads:** a newer background job could truncate the shared tmpfile while the handler `cat`s it after the previous job's signal. Jobs now render into a per-job scratch file (suffixed with the job's pid) and atomically `mv` it over the shared path; the parent removes the scratch of any job it kills mid-render.
5. **Unquoted tmpfile path:** the path was interpolated unquoted into the background job's command string — a Linux `TMPDIR` containing a space broke the prompt entirely (macOS `mktemp` ignores `TMPDIR`). The path now crosses into the job string-escaped and is expanded there as a variable, never re-parsed as syntax.

> Rebased onto main after #61 merged — the diff is now just this fix.

#### Motivation and Context

Follow-up hardening for #54 before it ships in a release. Defects 1–3 were reproduced experimentally in the isolated test HOME; 4–5 are race/edge hardening.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

Extended `tests/fish_prompt.test.fish`: resize-after-render in both async and fallback modes, jobs item in fallback mode, and a shadowed-`mktemp` block that routes the tmpfile into a directory with a space in its path and asserts no scratch/reload litter and clean removal on exit. Verified the new checks fail against the unfixed code with exactly the defect signatures (missing jobs icon, `files-after-reloads 3`, `files-after-exit 2`) and pass post-fix. Full suite green. Two-line variant spot-checked manually (status propagation + resize).

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
