### PR TITLE
fix(bug-report): exclude prompt-render internals from verbose output

### DIFF
--- a/functions/_tide_sub_bug-report.fish
+++ b/functions/_tide_sub_bug-report.fish
@@ -9,7 +9,7 @@ function _tide_sub_bug-report
         source && fisher install plttn/tide@v7"
     else if set -q _flag_verbose
         set --long | string match -r "^_?tide.*" | # Get only tide variables
-            string match -r --invert "^_tide_prompt_var.*" # Remove _tide_prompt_var
+            string match -r --invert "^_tide_prompt_" # Remove prompt-render internals (_tide_prompt_<pid>, _tide_prompt_tmpfile)
     else
         $fish_path --version | string match -qr "fish, version (?<fish_version>.*)"
         _tide_check_version Fish fish-shell/fish-shell "(?<v>[\d.]+)" $fish_version || return


### PR DESCRIPTION
#### Description

`tide bug-report -v` filters variables through `string match -r --invert "^_tide_prompt_var.*"` — but no variable named `_tide_prompt_var` has ever existed in this fork. The real internals are `_tide_prompt_<pid>` (the raw rendered prompt, ANSI escapes and all) and, once #62 lands, `_tide_prompt_tmpfile`, so verbose output dumped the full prompt contents. Match the `^_tide_prompt_` prefix instead; user-facing `tide_prompt_*` settings have no leading underscore and are unaffected.

Verified in the isolated test HOME: with both internals set (2 matching globals), `tide bug-report -v` now emits 0 `_tide_prompt_` lines while still listing all other tide variables.

#### How Has This Been Tested

- [x] I have tested using **MacOS**.
- [ ] I have tested using **Linux**.

#### Checklist

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)