### PR TITLE
fix(prompt): private tmpdir + guarded job kill

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -9,7 +9,12 @@ source (functions --details _tide_pwd)
 
 set -l prompt_var _tide_prompt_$fish_pid
 set -g $prompt_var
-set -q _tide_prompt_tmpfile || set -g _tide_prompt_tmpfile (mktemp) # global so `tide reload` reuses it instead of leaking one per reload
+# global so `tide reload` reuses it instead of leaking one per reload; a
+# private 0700 dir (rather than a bare mktemp file) keeps the per-render
+# scratch files -- created via `>` redirection at umask perms -- from ever
+# being exposed at a world-readable path
+set -q _tide_prompt_tmpdir || set -g _tide_prompt_tmpdir (mktemp -d)
+set -g _tide_prompt_tmpfile $_tide_prompt_tmpdir/prompt
 
 set_color normal | read -l color_normal
 status fish-path | read -l fish_path
@@ -68,9 +73,13 @@ command mv -f \$_tide_prompt_tmpfile.\$fish_pid \$_tide_prompt_tmpfile
 command kill -s USR1 $fish_pid 2>/dev/null" &
     builtin disown
 
-    # A job killed mid-render leaves its scratch file behind; its pid is
-    # the scratch suffix, so remove it only when the kill actually landed
-    command kill $_tide_last_pid 2>/dev/null && command rm -f $_tide_prompt_tmpfile.$_tide_last_pid
+    # A completed job has already mv'd its scratch file away, so its
+    # existence means the previous job is still running or died mid-render --
+    # only then is there anything to kill/clean up, and only then do we pay
+    # for the two external forks.
+    test -e $_tide_prompt_tmpfile.$_tide_last_pid &&
+        command kill $_tide_last_pid 2>/dev/null &&
+        command rm -f $_tide_prompt_tmpfile.$_tide_last_pid
     set -g _tide_last_pid $last_pid
 
     if not set -q _tide_signal_confirmed
@@ -153,5 +162,5 @@ end"
 end
 
 function _tide_on_fish_exit --on-event fish_exit
-    rm -f $_tide_prompt_tmpfile $_tide_prompt_tmpfile.$_tide_last_pid
+    set -q _tide_prompt_tmpdir && rm -rf $_tide_prompt_tmpdir
 end

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -53,18 +53,20 @@ env PATH="$fake_bin:$PATH" fish -i -c '
 # CHECK: {{.*}}✘ 1{{.*}}JOBS{{.*}}
 # CHECK: {{.*}}✘ 1{{.*}}JOBS{{.*}}
 
-# Tmpfile hygiene: a fake `mktemp` redirects the prompt tmpfile into a
-# watch dir whose path contains a space, proving the path survives the
-# background job's command string unmangled. macOS mktemp ignores TMPDIR,
-# so PATH-shadowing is the only reliable redirection. After a completed
-# render the scratch file must be renamed away (1 file), `tide reload`
-# must reuse the same tmpfile instead of minting new ones (still 1), and
-# exit must remove it (0).
+# Tmpfile hygiene: a fake `mktemp` redirects the prompt tmpdir into a watch
+# dir whose path contains a space, proving the path survives the background
+# job's command string unmangled. macOS mktemp ignores TMPDIR, so
+# PATH-shadowing is the only reliable redirection. The tmpdir itself is
+# created once and reused ($TIDE_TEST_TMPDIR always has exactly 1 entry --
+# the tmpdir -- until exit), so hygiene is checked *inside* it: after a
+# completed render the scratch file must be renamed away (1 file), `tide
+# reload` must reuse the same tmpdir instead of minting new ones (still 1
+# file), and exit must remove the whole tmpdir (0 entries at the watch root).
 set -l watch_root (mktemp -d)
 mkdir -p "$watch_root/tide tmp"
 set -l fake_mktemp_bin (mktemp -d)
 echo '#!/bin/sh
-exec /usr/bin/mktemp "$TIDE_TEST_TMPDIR/tide.XXXXXX"' >$fake_mktemp_bin/mktemp
+exec /usr/bin/mktemp -d "$TIDE_TEST_TMPDIR/tide.XXXXXX"' >$fake_mktemp_bin/mktemp
 chmod +x $fake_mktemp_bin/mktemp
 
 env TIDE_TEST_TMPDIR="$watch_root/tide tmp" PATH="$fake_mktemp_bin:$PATH" fish -i -c '
@@ -75,10 +77,10 @@ env TIDE_TEST_TMPDIR="$watch_root/tide tmp" PATH="$fake_mktemp_bin:$PATH" fish -
         sleep 0.01
     end
     _tide_decolor (fish_prompt)
-    echo files-after-render (command ls "$TIDE_TEST_TMPDIR" | count)
+    echo files-after-render (command ls $TIDE_TEST_TMPDIR/tide.*/ | count)
     tide reload
     tide reload
-    echo files-after-reloads (command ls "$TIDE_TEST_TMPDIR" | count)
+    echo files-after-reloads (command ls $TIDE_TEST_TMPDIR/tide.*/ | count)
 ' </dev/null
 # CHECK: {{.*}}✘ 1{{.*}}
 # CHECK: files-after-render 1


### PR DESCRIPTION
## Summary
- Render handoff moves from a single `mktemp` file into a private `mktemp -d` (0700) directory, so the per-render scratch file — created via `>` redirection at umask perms — is never exposed at a world-readable path after `mv -f` renames it over the shared file.
- The previous-job `kill`/`rm` in `_tide_dispatch_render` is now gated on the scratch file's existence: a completed render has already `mv`'d it away, so most renders skip the `command kill`/`command rm` forks entirely, and the narrow PID-reuse window (killing an unrelated recycled PID) shrinks to "job died mid-render AND its PID got reused before the next prompt."
- Exit cleanup now removes the whole tmpdir (`rm -rf`) instead of trying to track the last scratch file by name.

## Test plan
- [x] `mise run all` (fmt, lint, install, full littlecheck suite) — all green
- [x] Updated `tests/fish_prompt.test.fish`'s tmpfile-hygiene case for the tmpdir model (shim `mktemp -d`, assert 1 file inside the tmpdir after render, 1 after `tide reload` x2, 0 at the watch root after exit)
- [x] Manual check in a live interactive shell: tmpdir is `0700`, contains only the `prompt` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)