### PR TITLE
perf(items): memoize tool versions, drop docker/kubectl forks

### DIFF
--- a/functions/_tide_internal_vcs_jj.fish
+++ b/functions/_tide_internal_vcs_jj.fish
@@ -81,6 +81,7 @@ if(self.contained_in("::trunk() & ~::@"),
     set -l behind 0
     set -l ahead 0
     set -l display_bookmarks
+    set -l ancestor_depth_forks 0
 
     for line in $raw_lines
         if test "$line" = B
@@ -168,14 +169,25 @@ if(self.contained_in("::trunk() & ~::@"),
         else if test $nparts -eq 2
             # Ancestor with bookmarks: change_id, bookmarks
             set -l cid $parts[1]
-            set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
-                -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
-            set -l depth (count $depth_commits)
+            # Depth requires one extra `jj log` fork per ancestor bookmark;
+            # cap it so a deep stack of bookmarks can't fork unboundedly --
+            # bookmarks beyond the cap still show, just without `↑depth`.
+            set -l depth ""
+            if test $ancestor_depth_forks -lt 3
+                set ancestor_depth_forks (math $ancestor_depth_forks + 1)
+                set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
+                    -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
+                set depth (count $depth_commits)
+            end
             for bookmark in (string split ',' -- $parts[2])
                 set bookmark (string trim -- $bookmark)
                 if test -n "$bookmark"
                     set -l nobold (printf '\e[22m')
-                    set -a display_bookmarks "$magenta$bookmark$nobold$magenta↑$depth$reset$bold"
+                    if test -n "$depth"
+                        set -a display_bookmarks "$magenta$bookmark$nobold$magenta↑$depth$reset$bold"
+                    else
+                        set -a display_bookmarks "$magenta$bookmark$reset$bold"
+                    end
                 end
             end
         end

--- a/functions/_tide_item_bun.fish
+++ b/functions/_tide_item_bun.fish
@@ -1,6 +1,6 @@
 function _tide_item_bun
     if path is $_tide_parent_dirs/bun.lockb
-        bun --version | string match -qr "(?<v>.*)"
+        _tide_memoize bun "$(path resolve (command -s bun))" bun --version | string match -qr "(?<v>.*)"
         _tide_print_item bun $tide_bun_icon' ' $v
     end
 end

--- a/functions/_tide_item_crystal.fish
+++ b/functions/_tide_item_crystal.fish
@@ -1,6 +1,6 @@
 function _tide_item_crystal
     if path is $_tide_parent_dirs/shard.yml
-        crystal --version | string match -qr "(?<v>[\d.]+)"
+        _tide_memoize crystal "$(path resolve (command -s crystal))" crystal --version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item crystal $tide_crystal_icon' ' $v
     end
 end

--- a/functions/_tide_item_docker.fish
+++ b/functions/_tide_item_docker.fish
@@ -1,5 +1,11 @@
 function _tide_item_docker
-    docker context inspect --format '{{.Name}}' | read -l context
+    set -l context default
+    if set -q DOCKER_CONTEXT
+        set context $DOCKER_CONTEXT
+    else if test -e ~/.docker/config.json
+        read -lz content <~/.docker/config.json
+        string match -qr '"currentContext"\s*:\s*"(?<context>[^"]+)"' -- $content
+    end
     contains -- "$context" $tide_docker_default_contexts ||
         _tide_print_item docker $tide_docker_icon' ' $context
 end

--- a/functions/_tide_item_elixir.fish
+++ b/functions/_tide_item_elixir.fish
@@ -1,4 +1,4 @@
 function _tide_item_elixir
     path is $_tide_parent_dirs/mix.exs &&
-        _tide_print_item elixir $tide_elixir_icon' ' (elixir --short-version)
+        _tide_print_item elixir $tide_elixir_icon' ' (_tide_memoize elixir "$(path resolve (command -s elixir))" elixir --short-version)
 end

--- a/functions/_tide_item_go.fish
+++ b/functions/_tide_item_go.fish
@@ -1,6 +1,6 @@
 function _tide_item_go
     if path is $_tide_parent_dirs/go.mod
-        go version | string match -qr "(?<v>[\d.]+)"
+        _tide_memoize go "$(path resolve (command -s go))" go version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item go $tide_go_icon' ' $v
     end
 end

--- a/functions/_tide_item_java.fish
+++ b/functions/_tide_item_java.fish
@@ -1,6 +1,6 @@
 function _tide_item_java
     if path is $_tide_parent_dirs/pom.xml
-        java -version &| string match -qr "(?<v>[\d.]+)"
+        _tide_memoize java "$(path resolve (command -s java))" java -version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item java $tide_java_icon' ' $v
     end
 end

--- a/functions/_tide_item_kubectl.fish
+++ b/functions/_tide_item_kubectl.fish
@@ -1,4 +1,30 @@
 function _tide_item_kubectl
-    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
-        _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
+    set -l kubeconfig $HOME/.kube/config
+    set -q KUBECONFIG && set kubeconfig $KUBECONFIG
+
+    set -l ctx
+    set -l namespace
+    if string match -qv '*:*' -- $kubeconfig; and test -e $kubeconfig
+        read -lz content <$kubeconfig
+        string match -qr '(?m)^current-context:\s*[\'"]?(?<ctx>[^\'"\n]+?)[\'"]?\s*$' -- $content
+        if test -n "$ctx"
+            string match -qr '(?s)- context:\n(?<block>.*?)\n  name: '(string escape --style=regex -- $ctx)'(?:\n|$)' -- $content
+            test -n "$block" && string match -qr 'namespace: *(?<namespace>\S+)' -- $block
+        end
+    end
+
+    if test -z "$ctx"
+        # $KUBECONFIG lists multiple merged files, the default file doesn't
+        # exist, or the file didn't parse as expected -- let kubectl itself
+        # figure it out.
+        kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
+            _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
+        return
+    end
+
+    if test -n "$namespace"
+        _tide_print_item kubectl $tide_kubectl_icon' ' "$ctx/$namespace"
+    else
+        _tide_print_item kubectl $tide_kubectl_icon' ' $ctx
+    end
 end

--- a/functions/_tide_item_node.fish
+++ b/functions/_tide_item_node.fish
@@ -1,6 +1,6 @@
 function _tide_item_node
     if path is $_tide_parent_dirs/package.json and type -q node
-        node --version | string match -qr "v(?<v>.*)"
+        _tide_memoize node "$(path resolve (command -s node))" node --version | string match -qr "v(?<v>.*)"
         _tide_print_item node $tide_node_icon' ' $v
     end
 end

--- a/functions/_tide_item_php.fish
+++ b/functions/_tide_item_php.fish
@@ -1,6 +1,6 @@
 function _tide_item_php
     if path is $_tide_parent_dirs/composer.json
-        php --version | string match -qr "(?<v>[\d.]+)"
+        _tide_memoize php "$(path resolve (command -s php))" php --version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item php $tide_php_icon' ' $v
     end
 end

--- a/functions/_tide_item_python.fish
+++ b/functions/_tide_item_python.fish
@@ -1,9 +1,9 @@
 function _tide_item_python
     if test -n "$VIRTUAL_ENV"
         if command -q python3
-            python3 --version | string match -qr "(?<v>[\d.]+)"
+            _tide_memoize python "$(path resolve (command -s python3))" python3 --version | string match -qr "(?<v>[\d.]+)"
         else
-            python --version | string match -qr "(?<v>[\d.]+)"
+            _tide_memoize python "$(path resolve (command -s python))" python --version | string match -qr "(?<v>[\d.]+)"
         end
         string match -qr "^.*/(?<dir>.*)/(?<base>.*)" $VIRTUAL_ENV
         # pipenv $VIRTUAL_ENV looks like /home/ilan/.local/share/virtualenvs/pipenv_project-EwRYuc3l
@@ -18,9 +18,9 @@ function _tide_item_python
         end
     else if path is .python-version Pipfile __init__.py pyproject.toml requirements.txt setup.py
         if command -q python3
-            python3 --version | string match -qr "(?<v>[\d.]+)"
+            _tide_memoize python "$(path resolve (command -s python3))" python3 --version | string match -qr "(?<v>[\d.]+)"
         else
-            python --version | string match -qr "(?<v>[\d.]+)"
+            _tide_memoize python "$(path resolve (command -s python))" python --version | string match -qr "(?<v>[\d.]+)"
         end
         _tide_print_item python $tide_python_icon' ' $v
     end

--- a/functions/_tide_item_ruby.fish
+++ b/functions/_tide_item_ruby.fish
@@ -1,6 +1,6 @@
 function _tide_item_ruby
     if path is $_tide_parent_dirs/{*.gemspec,Gemfile,Rakefile,.ruby-version}
-        ruby --version | string match -qr "(?<v>[\d.]+)"
+        _tide_memoize ruby "$(path resolve (command -s ruby))" ruby --version | string match -qr "(?<v>[\d.]+)"
         _tide_print_item ruby $tide_ruby_icon' ' $v
     end
 end

--- a/functions/_tide_item_rustc.fish
+++ b/functions/_tide_item_rustc.fish
@@ -1,10 +1,10 @@
 function _tide_item_rustc
     if path is $_tide_parent_dirs/Cargo.toml
-        type -q rustc && set -f cmd 'rustc --version' ||
+        type -q rustc && set -f bin rustc && set -f cmd 'rustc --version' ||
             begin
-                type -q rustup && set -f cmd 'rustup show active-toolchain -v'
+                type -q rustup && set -f bin rustup && set -f cmd 'rustup show active-toolchain -v'
             end &&
-            eval "$cmd" | string match -qr "(?<v>\d+\.\d+\.\d+)" &&
+            _tide_memoize rustc "$(path resolve (command -s $bin))" eval "$cmd" | string match -qr "(?<v>\d+\.\d+\.\d+)" &&
             _tide_print_item rustc $tide_rustc_icon' ' $v
     end
 end

--- a/functions/_tide_item_zig.fish
+++ b/functions/_tide_item_zig.fish
@@ -1,6 +1,6 @@
 function _tide_item_zig
     if path is $_tide_parent_dirs/build.zig
-        zig version | string match -qr "(?<v>[\d.]+(-dev)?)"
+        _tide_memoize zig "$(path resolve (command -s zig))" zig version | string match -qr "(?<v>[\d.]+(-dev)?)"
         _tide_print_item zig $tide_zig_icon' ' $v
     end
 end

--- a/functions/_tide_memoize.fish
+++ b/functions/_tide_memoize.fish
@@ -1,0 +1,23 @@
+function _tide_memoize -a name key
+    if not set -q _tide_prompt_tmpdir
+        # No per-session tmpdir to cache into (e.g. called outside a real
+        # prompt render, such as directly from a test) -- just run it.
+        $argv[3..] 2>&1
+        return
+    end
+
+    set -l file $_tide_prompt_tmpdir/memo_$name
+    if test -e $file
+        read -lz whole <$file
+        set -l parts (string split -m1 \n -- $whole)
+        if test "$parts[1]" = "$key"
+            printf '%s' $parts[2]
+            return 0
+        end
+    end
+    set -l val ($argv[3..] 2>&1)
+    or return 1
+    string join \n -- $val | read -lz joined
+    printf '%s\n%s' $key $joined >$file
+    printf '%s' $joined
+end

--- a/tests/_tide_item_docker.test.fish
+++ b/tests/_tide_item_docker.test.fish
@@ -5,17 +5,33 @@ function _docker
     _tide_decolor (_tide_item_docker)
 end
 
-set -lx tide_docker_icon 
+set -l tmpdir (mktemp -d)
+cd $tmpdir
+set -lx HOME $tmpdir
+mkdir -p $tmpdir/.docker
 
-mock docker "context inspect" "echo default"
+set -lx tide_docker_icon
+
+# No config.json and no $DOCKER_CONTEXT -- falls back to the implicit
+# "default" context, filtered by tide_docker_default_contexts same as the
+# shipped default config (functions/tide/configure/configs/*.fish).
+set -lx tide_docker_default_contexts default colima
 _docker # CHECK:
 
-mock docker "context inspect" "echo colima"
+# currentContext read from config.json, still filtered
+echo '{"currentContext": "colima"}' >$tmpdir/.docker/config.json
 _docker # CHECK:
 
-mock docker "context inspect" "echo curr-context"
-_docker # CHECK:  curr-context
+# currentContext read from config.json, not filtered
+echo '{"currentContext": "curr-context"}' >$tmpdir/.docker/config.json
+_docker # CHECK:  curr-context
 
-mock docker "context inspect" "echo curr-context"
 set -lx tide_docker_default_contexts curr-context
 _docker # CHECK:
+set -e tide_docker_default_contexts
+
+# $DOCKER_CONTEXT overrides config.json
+set -lx DOCKER_CONTEXT overridden
+_docker # CHECK:  overridden
+
+command rm -r $tmpdir

--- a/tests/_tide_item_kubectl.test.fish
+++ b/tests/_tide_item_kubectl.test.fish
@@ -7,6 +7,7 @@ end
 
 set -lx tide_kubectl_icon ⎈
 
+# -------- no kubeconfig file: falls back to the kubectl CLI --------
 mock kubectl "config view --minify --output" "echo error: current-context must exist in order to minify >&2; false"
 _kubectl # CHECK:
 
@@ -18,3 +19,40 @@ _kubectl # CHECK: ⎈ curr-context
 
 mock kubectl "config view --minify --output" "echo curr-context/curr-namespace"
 _kubectl # CHECK: ⎈ curr-context/curr-namespace
+
+# -------- single-file kubeconfig: parsed without forking kubectl --------
+set -l tmpdir (mktemp -d)
+set -lx HOME $tmpdir
+set -e KUBECONFIG
+mkdir -p $tmpdir/.kube
+
+echo 'current-context: dev
+contexts:
+- context:
+    cluster: dev-cluster
+  name: dev
+- context:
+    cluster: prod-cluster
+    namespace: production
+  name: prod' >$tmpdir/.kube/config
+
+_kubectl # CHECK: ⎈ dev
+
+echo 'current-context: prod
+contexts:
+- context:
+    cluster: dev-cluster
+  name: dev
+- context:
+    cluster: prod-cluster
+    namespace: production
+  name: prod' >$tmpdir/.kube/config
+
+_kubectl # CHECK: ⎈ prod/production
+
+# -------- $KUBECONFIG with multiple paths: falls back to the CLI --------
+set -lx KUBECONFIG "$tmpdir/.kube/config:$tmpdir/.kube/other"
+mock kubectl "config view --minify --output" "echo merged-context/merged-ns"
+_kubectl # CHECK: ⎈ merged-context/merged-ns
+
+command rm -r $tmpdir

--- a/tests/_tide_memoize.test.fish
+++ b/tests/_tide_memoize.test.fish
@@ -1,0 +1,42 @@
+# RUN: %fish %s
+set -l tmpdir (mktemp -d)
+
+# No $_tide_prompt_tmpdir set: runs directly, no caching, no error.
+set -e _tide_prompt_tmpdir
+_tide_memoize noop keyA echo direct # CHECK: direct
+
+set -gx _tide_prompt_tmpdir $tmpdir
+set -l counter (mktemp)
+echo 0 >$counter
+
+function _memoized_call -a counter
+    set -l n (cat $counter)
+    math $n + 1 >$counter
+    echo v1.2.3
+end
+
+# First call: cache miss, underlying command runs (counter -> 1).
+_tide_memoize thing keyA _memoized_call $counter # CHECK: v1.2.3
+cat $counter # CHECK: 1
+
+# Second call, same key: cache hit, underlying command does not run again.
+_tide_memoize thing keyA _memoized_call $counter # CHECK: v1.2.3
+cat $counter # CHECK: 1
+
+# Key changes: cache miss again (counter -> 2).
+_tide_memoize thing keyB _memoized_call $counter # CHECK: v1.2.3
+cat $counter # CHECK: 2
+
+# Multi-line output round-trips intact through both the miss and hit paths.
+function _multiline_call
+    echo line-one
+    echo line-two
+end
+_tide_memoize multi keyA _multiline_call
+# CHECK: line-one
+# CHECK: line-two
+_tide_memoize multi keyA _multiline_call
+# CHECK: line-one
+# CHECK: line-two
+
+command rm -r $tmpdir $counter


### PR DESCRIPTION
## Summary
- Language-version items (node, python, bun, go, ruby, rustc, java, elixir, php, crystal, zig) fork their tool's `--version` on every single render inside a matching project, even though the version essentially never changes within a shell session. A new `_tide_memoize` helper (`functions/_tide_memoize.fish`) caches each tool's raw version output in a per-session file keyed on the resolved binary path (`path resolve (command -s tool)`), so a version-manager switch (asdf/mise/rbenv/etc, which changes the resolved path) still invalidates correctly. Cache misses cost one extra file write; hits cost builtin file reads only — no fork. When called outside a real prompt render (e.g. directly from a test, where `$_tide_prompt_tmpdir` isn't set), it degrades to running the command directly with no caching, so existing behavior for anything not going through `fish_prompt.fish` is unchanged.
- `docker`/`kubectl` items forked their CLI unconditionally every render just to read the current context. Both now parse the relevant config file directly (`~/.docker/config.json`'s `currentContext`, `~/.kube/config`'s `current-context`/`namespace`) with builtins only. kubectl falls back to invoking the CLI when `$KUBECONFIG` lists multiple merged files or the default file doesn't exist, so nothing breaks for merged-config setups.
- jj's per-bookmarked-ancestor `↑depth` computation forked one `jj log` per ancestor with no bound; capped at the first 3 so a deep bookmark stack can't fork unboundedly (further bookmarks still render, just without the depth suffix).

## Test plan
- [x] `mise run all` (fmt, lint, install, full littlecheck suite) — all green
- [x] New `tests/_tide_memoize.test.fish`: cache hit avoids re-running the underlying command, a key change forces a miss, multi-line values round-trip intact through both the miss and hit paths, and the no-tmpdir passthrough case works
- [x] Rewrote `tests/_tide_item_docker.test.fish` and `tests/_tide_item_kubectl.test.fish` to use config-file fixtures for the new builtin-parsing path, while keeping CLI-mock cases as regression coverage for the fallback paths (missing file, multi-path `$KUBECONFIG`)
- [x] Found and fixed a real bug during testing: embedding an unquoted, possibly-empty command substitution directly in `_tide_memoize`'s argument list caused the whole positional argument list to shift when the substitution produced no output (tool not installed, or mocked as a fish function rather than a real binary) — every call site now double-quotes the substitution so an empty result still counts as one (empty) argument
- [x] Manually verified against real installed tools (not just mocks) that the memoized cache key is the actual resolved binary path and that a cache hit returns the correct cached version without re-invoking the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)