### PR TITLE
chore(ci): pin actions, fix fisher bootstrap URL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,33 +18,33 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v6
-      - uses: fish-shop/install-fish-shell@v2
-      - uses: fish-shop/install-plugin-manager@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: fish-shop/install-fish-shell@e83b4f8c7c4d80c3b65ee0eb5d0e3bf4816536ee # v2
+      - uses: fish-shop/install-plugin-manager@3a4a1f1aff085f23d3817468a042acc1e6471f59 # v2
         with:
           plugin-manager: fisher
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4
       - run: mise run test
 
   syntax-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: fish-shop/install-fish-shell@v2
-      - uses: fish-shop/syntax-check@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: fish-shop/install-fish-shell@e83b4f8c7c4d80c3b65ee0eb5d0e3bf4816536ee # v2
+      - uses: fish-shop/syntax-check@3d500356d24bce50fab4e335245f224918929284 # v2
 
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: fish-shop/install-fish-shell@v2
-      - uses: fish-shop/indent-check@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: fish-shop/install-fish-shell@e83b4f8c7c4d80c3b65ee0eb5d0e3bf4816536ee # v2
+      - uses: fish-shop/indent-check@ee3ad08117b99aa5e41e706ace13ffd4f8c22412 # v2
 
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: raven-actions/actionlint@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2
 
   gitleaks:
     runs-on: ubuntu-latest
@@ -52,10 +52,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,6 +64,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -13,4 +13,4 @@ jobs:
   lock-threads:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       major: ${{ steps.release.outputs.major }}
       minor: ${{ steps.release.outputs.minor }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Tag major and minor versions
         env:
           MAJOR: ${{ needs.release-please.outputs.major }}

--- a/conf.d/_tide_init.fish
+++ b/conf.d/_tide_init.fish
@@ -42,6 +42,10 @@ end
 
 function _tide_init_uninstall --on-event _tide_init_uninstall
     set -e VIRTUAL_ENV_DISABLE_PROMPT
-    set -e (set -U --names | string match --entire -r '^_?tide')
-    functions --erase (functions --all | string match --entire -r '^_?tide')
+
+    set -l tide_uvars (set -U --names | string match --entire -r '^_?tide')
+    set -q tide_uvars[1] && set -e $tide_uvars
+
+    set -l tide_functions (functions --all | string match --entire -r '^_?tide')
+    set -q tide_functions[1] && functions --erase $tide_functions
 end

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ run = 'find . -name "*.fish" -type f -print0 | xargs -0 -n1 fish --no-execute'
 [tasks.install]
 description = 'Install Tide and test dependencies via fisher'
 run = '''
-fish -c 'type -q fisher || begin; curl -sL https://git.io/fisher | source; fisher install jorgebucaran/fisher; end'
+fish -c 'type -q fisher || begin; curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source; fisher install jorgebucaran/fisher; end'
 fish -c 'if test -e ~/.config/fish/functions/tide.fish; else; fisher install . >/dev/null; end'
 '''
 

--- a/scripts/test.fish
+++ b/scripts/test.fish
@@ -2,7 +2,7 @@
 
 set -l inner_cmd "
 type -q fisher || begin
-    curl -sL https://git.io/fisher | source #when running in CI like GHA, we'll have already installed Fisher so this is a no-op
+    curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source #when running in CI like GHA, we'll have already installed Fisher so this is a no-op
     fisher install jorgebucaran/fisher
 end
 fisher install . >/dev/null


### PR DESCRIPTION
## Summary
- Pin every third-party GitHub Action across `.github/workflows/{CI,release-please,lock-threads}.yml` to its resolved commit SHA (with the previous version tag kept as a trailing comment), instead of a mutable tag — the standard supply-chain hardening measure so a compromised/retagged release can't silently run in CI.
- `scripts/test.fish` and `mise.toml` switch their fisher bootstrap from `https://git.io/fisher` to `https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish` (the URL `_tide_sub_bug-report.fish` already uses). Note: I verified `git.io/fisher` actually still resolves fine (301 → the same raw URL, 200 OK) — it isn't dead, so this is a minor consistency/one-less-redirect cleanup, not a broken-link fix.
- `conf.d/_tide_init.fish`'s uninstall handler (`_tide_init_uninstall`) called `set -e (...)` / `functions --erase (...)` directly on a command substitution that produces zero arguments if nothing currently matches `^_?tide` — both are hard errors in fish with no arguments. Now captured into a local list first and guarded with `set -q list[1]` before acting.

## Test plan
- [x] `mise run all` (fmt, lint, install, full littlecheck suite) — all green
- [x] Verified live that both the old and new fisher URLs resolve to valid, working `fisher.fish` content
- [x] Verified the new SHAs by resolving each `owner/repo@tag` via `gh api repos/<owner>/<repo>/commits/<tag>` (resolves through annotated tags to the actual commit, not the tag object)
- [x] Manually exercised `_tide_init_uninstall` in a fresh, isolated `$HOME`/`$XDG_CONFIG_HOME` with zero `tide_*` universal variables or functions present — confirmed it now exits 0 instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)