### PR TITLE
chore(mise): pin littlecheck.py fetch to a commit SHA

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,9 @@ fish -c 'if test -e ~/.config/fish/functions/tide.fish; else; fisher install . >
 
 [tasks.littlecheck]
 description = 'Download littlecheck test runner'
-run = 'curl -sL https://raw.githubusercontent.com/ridiculousfish/littlecheck/HEAD/littlecheck/littlecheck.py -o littlecheck.py'
+# littlecheck has no tags/releases to pin to, so we pin a commit SHA instead of
+# tracking HEAD, so upstream changes can't silently break our tests/CI.
+run = 'curl -sL https://raw.githubusercontent.com/ridiculousfish/littlecheck/c44c157d3666b9a447e20977eec6eb4bd2a0c304/littlecheck/littlecheck.py -o littlecheck.py'
 
 [tasks.test]
 description = 'Run test suite'


### PR DESCRIPTION
## Summary
- littlecheck has no tags/releases, so `mise run test` was fetching `littlecheck.py` from upstream `HEAD` on every run — a future upstream change could silently break tests/CI with no corresponding change here.
- Pin the download to the current commit SHA instead.

## Test plan
- [x] `mise run littlecheck` downloads successfully from the pinned SHA
- [x] `mise run test` passes (all 30 test files)