### PR TITLE
fix(prompt): kill last render job before removing tmpdir on exit

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -162,5 +162,17 @@ end"
 end
 
 function _tide_on_fish_exit --on-event fish_exit
+    # The last dispatched render job is disowned, so nothing else waits for
+    # it -- kill it and confirm it's dead before removing the tmpdir it
+    # writes into, or a job that's still starting up (e.g. a nested shell
+    # exited right after launch) can fail its redirect into a dir we just
+    # deleted and print a spurious warning.
+    if set -q _tide_last_pid
+        command kill $_tide_last_pid 2>/dev/null
+        for _tide_i in (seq 1 10)
+            command kill -0 $_tide_last_pid 2>/dev/null || break
+            sleep 0.01
+        end
+    end
     set -q _tide_prompt_tmpdir && rm -rf $_tide_prompt_tmpdir
 end

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -89,4 +89,29 @@ echo files-after-exit (command ls "$watch_root/tide tmp" | count)
 # CHECK: files-after-exit 0
 
 command rm -r $fake_bin $fake_mktemp_bin $watch_root
+
+# fish_exit must not delete the tmpdir out from under the last dispatched
+# render job while it's still alive -- it should kill $_tide_last_pid and
+# confirm it's dead first. Otherwise a slow-starting job (e.g. one from a
+# nested shell immediately Ctrl-D'd right after launch) can still be
+# mid-startup when its `>` redirect target disappears, printing a spurious
+# "path does not exist" warning. Simulate that slow job directly: a real
+# fish process which, unless killed first, would write into the tmpdir well
+# after fish_exit has already removed it.
+set -l stderr_log (mktemp)
+fish -i -c '
+    fish_prompt >/dev/null
+    for i in (seq 1 50)
+        set -q _tide_repaint && break
+        sleep 0.01
+    end
+    status fish-path | read -l fish_path
+    $fish_path -c "sleep 0.3; echo late-write >$_tide_prompt_tmpfile.fake" &
+    set -g _tide_last_pid $last_pid
+' </dev/null 2>$stderr_log
+sleep 0.5
+echo stderr-lines (count <$stderr_log)
+# CHECK: stderr-lines 0
+command rm -f $stderr_log
+
 set -e tide_left_prompt_items tide_right_prompt_items tide_prompt_add_newline_before tide_left_prompt_frame_enabled tide_right_prompt_frame_enabled tide_prompt_min_cols tide_status_icon tide_status_icon_failure tide_jobs_icon tide_jobs_number_threshold


### PR DESCRIPTION
The disowned background render job is never waited on, so fish_exit could delete the prompt tmpdir out from under a still-starting job (e.g. a nested shell exited right after launch), which then failed its redirect into the now-missing directory and printed a spurious warning. Kill $_tide_last_pid and confirm it's dead before rm -rf'ing the tmpdir.

<!-- Provide a general summary of your changes in the Title above. -->
<!-- The title must be a Conventional Commit (e.g. "fix: ..." or "feat: ...") -->
<!-- see CONTRIBUTING.md#pull-request-titles — it becomes the changelog entry. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [ ] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [ ] I am ready to update the wiki accordingly.
- [ ] I have updated the tests accordingly.
