### PR TITLE
fix(vcs): avoid per-bookmark jj log calls and fix ahead-count undercount

### DIFF
--- a/functions/_tide_internal_vcs_jj.fish
+++ b/functions/_tide_internal_vcs_jj.fish
@@ -1,10 +1,22 @@
 # full credits to https://github.com/nertzy/fish_jj_prompt
 # for a lot of the logic here, modified for Tide
 function _tide_internal_vcs_jj
+    # A bare "M\n" line is emitted immediately before a commit's own content
+    # line whenever that commit has more than one parent. It only fires for
+    # @ and ahead-of-trunk commits (never the trunk() boundary itself, since
+    # merges are common in a long-lived trunk's own history and are
+    # irrelevant to the ahead-path's shape) -- it lets the loop below detect,
+    # for free from this single jj invocation, whether every bookmarked
+    # ancestor's position in $raw_lines can be trusted as its distance from
+    # @. That trust breaks the moment the ahead-path branches: jj's log
+    # order fully drains one parent line before the other, so a bookmark on
+    # the second-visited branch gets a position inflated by the first
+    # branch's length.
     set -l tmpl '
 if(self.contained_in("::trunk() & ~::@"),
     "B\n",
     if(self.contained_in("@"),
+        if(parents.len() > 1, "M\n") ++
         change_id.shortest() ++
             if(divergent, "/" ++ change_offset) ++
         "\t" ++
@@ -32,11 +44,13 @@ if(self.contained_in("::trunk() & ~::@"),
     ,
         if(self.contained_in("trunk()"),
             ".\n",
+            if(parents.len() > 1, "M\n") ++
             if(local_bookmarks,
                 change_id.shortest() ++ "\t" ++ separate(",",
                     local_bookmarks.join(","),
                     if(tags, tags.join(",")),
                 ) ++ "\n",
+                "\n",
             )
         )
     )
@@ -53,6 +67,15 @@ if(self.contained_in("::trunk() & ~::@"),
     # crafted commit description could otherwise inject escape sequences.
     # \t is preserved: it's this template's field separator.
     set raw_lines (string replace -ra '[\x00-\x08\x0b-\x1f\x7f]' '' -- $raw_lines)
+
+    # If the ahead-path never branches, each bookmarked ancestor's position
+    # in $raw_lines (tracked below via $ahead) equals its distance from @,
+    # so we can skip the per-bookmark `jj log` call entirely. A single "M"
+    # line anywhere means it doesn't, and every bookmark falls back to the
+    # old per-cid query for correctness.
+    set -l has_merge 0
+    contains -- M $raw_lines
+    and set has_merge 1
 
     # Colors
     # if bg color is normal, we can use matching jj colors
@@ -91,6 +114,9 @@ if(self.contained_in("::trunk() & ~::@"),
     for line in $raw_lines
         if test "$line" = B
             set behind (math $behind + 1)
+            continue
+        end
+        if test "$line" = M
             continue
         end
 
@@ -174,9 +200,14 @@ if(self.contained_in("::trunk() & ~::@"),
         else if test $nparts -eq 2
             # Ancestor with bookmarks: change_id, bookmarks
             set -l cid $parts[1]
-            set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
-                -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
-            set -l depth (count $depth_commits)
+            set -l depth
+            if test $has_merge -eq 1
+                set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
+                    -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
+                set depth (count $depth_commits)
+            else
+                set depth (math $ahead - 1)
+            end
             for bookmark in (string split ',' -- $parts[2])
                 set bookmark (string trim -- $bookmark)
                 if test -n "$bookmark"
@@ -185,7 +216,7 @@ if(self.contained_in("::trunk() & ~::@"),
                 end
             end
         end
-        # "." lines (nparts=1, not "B") just count toward ahead
+        # "." lines and blank lines (nparts=1, not "B"/"M") just count toward ahead
     end
 
     # Assemble prompt

--- a/tests/_tide_item_vcs.test.fish
+++ b/tests/_tide_item_vcs.test.fish
@@ -128,5 +128,33 @@ cd $dir/jj-scrub-repo
 set -e tide_jj_show_description
 _vcs_item # CHECK: (@ abc123 main def456 * evil[31mdesc ↑1)
 
+# -------- jj bookmark depth: position-based fast path --------
+# Regression test: an ahead commit with no local bookmark previously produced
+# no template output at all, so both the total ahead count and (before this
+# fix) a position-based depth would silently undercount. Main log response
+# here is @ (no bookmarks) + one bookmarked ancestor ("feature") + one
+# unbookmarked ancestor -- 3 ahead commits total. The "::@ ~" case exits
+# nonzero (no output) so that if the fast path were wrongly skipped in favor
+# of the per-bookmark fallback, the resulting depth would visibly be 0
+# instead of the correct 1, failing the CHECK below.
+mkdir -p $dir/jj-fastpath-repo/.jj
+printf '#!/bin/sh\ncmd="$*"\ncase "$cmd" in\n  *"workspace list"*) printf "default\\n" ;;\n  *"::@ ~"*) exit 1 ;;\n  *"log"*) printf "xyz999\\t.\\t.\\tdefault\\tdef999\\t*\\tfalse\\tdesc\\nanc123\\tfeature\\n\\n" ;;\n  *) exit 0 ;;\nesac\n' >$dir/bin/jj
+cd $dir/jj-fastpath-repo
+_vcs_item # CHECK: (@ xyz999 def999 * desc feature↑1 ↑3)
+
+# -------- jj bookmark depth: merge-detection fallback --------
+# Same 3 ahead commits, but the main log response now also emits a bare "M"
+# line (this fires when a commit in the ahead-path has more than one
+# parent) -- so depth must come from the old per-bookmark `jj log` call
+# instead of list position. The canned fallback response (3 dots -> depth 3)
+# is deliberately different from the fast-path's depth (1), so the rendered
+# value proves which code path actually ran. The total ahead count (↑3)
+# must be unchanged from the fast-path test, confirming the "M" line itself
+# isn't miscounted as an ahead commit.
+mkdir -p $dir/jj-merge-repo/.jj
+printf '#!/bin/sh\ncmd="$*"\ncase "$cmd" in\n  *"workspace list"*) printf "default\\n" ;;\n  *"::@ ~"*) printf ".\\n.\\n.\\n" ;;\n  *"log"*) printf "M\\nxyz999\\t.\\t.\\tdefault\\tdef999\\t*\\tfalse\\tdesc\\nanc123\\tfeature\\n\\n" ;;\n  *) exit 0 ;;\nesac\n' >$dir/bin/jj
+cd $dir/jj-merge-repo
+_vcs_item # CHECK: (@ xyz999 def999 * desc feature↑3 ↑3)
+
 # ------ cleanup ------
 command rm -r $dir


### PR DESCRIPTION
## Summary
- `_tide_internal_vcs_jj` shelled out to `jj log` once per bookmarked ancestor commit just to compute its `↑N` depth annotation — process count scaled with the number of stacked bookmarks. Depth is now derived for free from each bookmarked line's position in the single `jj log` call already being made, falling back to the old per-bookmark query only when a merge is detected anywhere in the ahead-path (verified against real jj that position-based depth is unsafe once history branches — the log traversal fully drains one parent line before the other).
- Along the way, found and fixed a pre-existing bug, independent of the above: the template's ahead-commit branch had no `else`, so any ahead commit without a local bookmark emitted **zero** template output — silently undercounting the total `↑N` ahead count for years. Fixed by giving that branch an explicit `else "\n"`.

## Test plan
- [x] `mise run fmt && mise run lint`
- [x] `mise run test` (full littlecheck suite, including two new cases in `tests/_tide_item_vcs.test.fish` covering the fast path and the merge-fallback path, using distinguishable canned depths so the `# CHECK:` assertions prove which code path actually ran)
- [x] Manually verified against real `jj` (not just the fake test binary) by running the actual pre-fix and post-fix function side by side against several scratch repos: a linear stack with unbookmarked gap commits (ahead count corrects from `↑3` to the true `↑5`, per-bookmark depths unchanged), and a repo with two divergent bookmarked branches merged into `@` (all depths match ground truth exactly, including cases where naive position-based guessing would have been wrong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)