### PR TITLE
fix(vcs): cap per-bookmark jj log forks in jj merge-ahead fallback path

### DIFF
--- a/functions/_tide_internal_vcs_jj.fish
+++ b/functions/_tide_internal_vcs_jj.fish
@@ -110,6 +110,7 @@ if(self.contained_in("::trunk() & ~::@"),
     set -l behind 0
     set -l ahead 0
     set -l display_bookmarks
+    set -l ancestor_depth_forks 0
 
     for line in $raw_lines
         if test "$line" = B
@@ -200,11 +201,18 @@ if(self.contained_in("::trunk() & ~::@"),
         else if test $nparts -eq 2
             # Ancestor with bookmarks: change_id, bookmarks
             set -l cid $parts[1]
-            set -l depth
+            set -l depth ""
             if test $has_merge -eq 1
-                set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
-                    -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
-                set depth (count $depth_commits)
+                # Depth requires one extra `jj log` fork per ancestor bookmark;
+                # cap it so a deep stack of bookmarks on a merge-containing
+                # ahead-path can't fork unboundedly -- bookmarks beyond the
+                # cap still show, just without the `↑depth` suffix.
+                if test $ancestor_depth_forks -lt 3
+                    set ancestor_depth_forks (math $ancestor_depth_forks + 1)
+                    set -l depth_commits (jj log --no-pager --no-graph --ignore-working-copy --color=never \
+                        -r "$cid::@ ~ $cid" -T '".\n"' 2>/dev/null)
+                    set depth (count $depth_commits)
+                end
             else
                 set depth (math $ahead - 1)
             end
@@ -212,7 +220,11 @@ if(self.contained_in("::trunk() & ~::@"),
                 set bookmark (string trim -- $bookmark)
                 if test -n "$bookmark"
                     set -l nobold (printf '\e[22m')
-                    set -a display_bookmarks "$magenta$bookmark$nobold$magenta↑$depth$reset$bold"
+                    if test -n "$depth"
+                        set -a display_bookmarks "$magenta$bookmark$nobold$magenta↑$depth$reset$bold"
+                    else
+                        set -a display_bookmarks "$magenta$bookmark$reset$bold"
+                    end
                 end
             end
         end


### PR DESCRIPTION
## Summary
- #73 already removed the per-bookmark `jj log` fork in the common case (ahead-path has no merge commit), computing each bookmark's `↑depth` from its position in the single `jj log` call the item already makes.
- It still falls back to one `jj log` fork per bookmarked ancestor when the ahead-path does contain a merge, since position-in-output no longer reliably equals distance-from-`@` once the traversal branches. That fallback had no bound, so a deep bookmark stack on a merge-containing ahead-path could still fork unboundedly.
- Caps that fallback at 3 forks. Bookmarks beyond the cap still render, just without the `↑depth` suffix.

Split out of #66, which also bundled an unrelated version-caching change that turned out to have a correctness bug and was dropped.

## Test plan
- [x] `mise run fmt`, `mise run lint`, `mise run test` — all green
- Manually verified in a scratch jj repo with a merge commit and 5 bookmarked ancestors on the ahead-path: the first 3 (by traversal order) get `↑depth`, the remaining 2 render without it, and `jj log` is invoked 4 times total (1 main query + 3 capped forks) instead of 6.
- No dedicated test file exists for `_tide_internal_vcs_jj.fish` (pre-existing gap, not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)