### PR TITLE
fix(sudo): Exclude root from displaying sudo indicator

### DIFF
--- a/functions/_tide_item_sudo.fish
+++ b/functions/_tide_item_sudo.fish
@@ -1,5 +1,3 @@
 function _tide_item_sudo
-    if sudo -n true 2>/dev/null
-        _tide_print_item sudo $tide_sudo_icon
-    end
+    test "$EUID" != 0 && sudo -n true 2>/dev/null && _tide_print_item sudo $tide_sudo_icon
 end


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
<!-- The title must be a Conventional Commit (e.g. "fix: ..." or "feat: ...") -->
<!-- see CONTRIBUTING.md#pull-request-titles — it becomes the changelog entry. -->

#### Description

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

Excludes `root` from displaying the sudo cache indicator

