### PR TITLE
perf(items): read docker/kubectl context from config files instead of forking CLI

### DIFF
--- a/functions/_tide_item_docker.fish
+++ b/functions/_tide_item_docker.fish
@@ -1,5 +1,11 @@
 function _tide_item_docker
-    docker context inspect --format '{{.Name}}' | read -l context
+    set -l context default
+    if set -q DOCKER_CONTEXT
+        set context $DOCKER_CONTEXT
+    else if test -e ~/.docker/config.json
+        read -lz content <~/.docker/config.json
+        string match -qr '"currentContext"\s*:\s*"(?<context>[^"]+)"' -- $content
+    end
     contains -- "$context" $tide_docker_default_contexts ||
         _tide_print_item docker $tide_docker_icon' ' $context
 end

--- a/functions/_tide_item_kubectl.fish
+++ b/functions/_tide_item_kubectl.fish
@@ -1,4 +1,30 @@
 function _tide_item_kubectl
-    kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
-        _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
+    set -l kubeconfig $HOME/.kube/config
+    set -q KUBECONFIG && set kubeconfig $KUBECONFIG
+
+    set -l ctx
+    set -l namespace
+    if string match -qv '*:*' -- $kubeconfig; and test -e $kubeconfig
+        read -lz content <$kubeconfig
+        string match -qr '(?m)^current-context:\s*[\'"]?(?<ctx>[^\'"\n]+?)[\'"]?\s*$' -- $content
+        if test -n "$ctx"
+            string match -qr '(?s)- context:\n(?<block>(?:(?!\n- context:).)*?)\n  name: '(string escape --style=regex -- $ctx)'(?:\n|$)' -- $content
+            test -n "$block" && string match -qr 'namespace: *(?<namespace>\S+)' -- $block
+        end
+    end
+
+    if test -z "$ctx"
+        # $KUBECONFIG lists multiple merged files, the default file doesn't
+        # exist, or the file didn't parse as expected -- let kubectl itself
+        # figure it out.
+        kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
+            _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
+        return
+    end
+
+    if test -n "$namespace"
+        _tide_print_item kubectl $tide_kubectl_icon' ' "$ctx/$namespace"
+    else
+        _tide_print_item kubectl $tide_kubectl_icon' ' $ctx
+    end
 end

--- a/tests/_tide_item_docker.test.fish
+++ b/tests/_tide_item_docker.test.fish
@@ -5,17 +5,33 @@ function _docker
     _tide_decolor (_tide_item_docker)
 end
 
-set -lx tide_docker_icon 
+set -l tmpdir (mktemp -d)
+cd $tmpdir
+set -lx HOME $tmpdir
+mkdir -p $tmpdir/.docker
 
-mock docker "context inspect" "echo default"
+set -lx tide_docker_icon
+
+# No config.json and no $DOCKER_CONTEXT -- falls back to the implicit
+# "default" context, filtered by tide_docker_default_contexts same as the
+# shipped default config (functions/tide/configure/configs/*.fish).
+set -lx tide_docker_default_contexts default colima
 _docker # CHECK:
 
-mock docker "context inspect" "echo colima"
+# currentContext read from config.json, still filtered
+echo '{"currentContext": "colima"}' >$tmpdir/.docker/config.json
 _docker # CHECK:
 
-mock docker "context inspect" "echo curr-context"
-_docker # CHECK:  curr-context
+# currentContext read from config.json, not filtered
+echo '{"currentContext": "curr-context"}' >$tmpdir/.docker/config.json
+_docker # CHECK:  curr-context
 
-mock docker "context inspect" "echo curr-context"
 set -lx tide_docker_default_contexts curr-context
 _docker # CHECK:
+set -e tide_docker_default_contexts
+
+# $DOCKER_CONTEXT overrides config.json
+set -lx DOCKER_CONTEXT overridden
+_docker # CHECK:  overridden
+
+command rm -r $tmpdir

--- a/tests/_tide_item_kubectl.test.fish
+++ b/tests/_tide_item_kubectl.test.fish
@@ -7,6 +7,7 @@ end
 
 set -lx tide_kubectl_icon ⎈
 
+# -------- no kubeconfig file: falls back to the kubectl CLI --------
 mock kubectl "config view --minify --output" "echo error: current-context must exist in order to minify >&2; false"
 _kubectl # CHECK:
 
@@ -18,3 +19,55 @@ _kubectl # CHECK: ⎈ curr-context
 
 mock kubectl "config view --minify --output" "echo curr-context/curr-namespace"
 _kubectl # CHECK: ⎈ curr-context/curr-namespace
+
+# -------- single-file kubeconfig: parsed without forking kubectl --------
+set -l tmpdir (mktemp -d)
+set -lx HOME $tmpdir
+set -e KUBECONFIG
+mkdir -p $tmpdir/.kube
+
+echo 'current-context: dev
+contexts:
+- context:
+    cluster: dev-cluster
+  name: dev
+- context:
+    cluster: prod-cluster
+    namespace: production
+  name: prod' >$tmpdir/.kube/config
+
+_kubectl # CHECK: ⎈ dev
+
+echo 'current-context: prod
+contexts:
+- context:
+    cluster: dev-cluster
+  name: dev
+- context:
+    cluster: prod-cluster
+    namespace: production
+  name: prod' >$tmpdir/.kube/config
+
+_kubectl # CHECK: ⎈ prod/production
+
+# regression: an earlier context's own namespace must not leak into a later
+# context's match
+echo 'current-context: prod
+contexts:
+- context:
+    cluster: dev-cluster
+    namespace: dev-ns
+  name: dev
+- context:
+    cluster: prod-cluster
+    namespace: production
+  name: prod' >$tmpdir/.kube/config
+
+_kubectl # CHECK: ⎈ prod/production
+
+# -------- $KUBECONFIG with multiple paths: falls back to the CLI --------
+set -lx KUBECONFIG "$tmpdir/.kube/config:$tmpdir/.kube/other"
+mock kubectl "config view --minify --output" "echo merged-context/merged-ns"
+_kubectl # CHECK: ⎈ merged-context/merged-ns
+
+command rm -r $tmpdir


### PR DESCRIPTION
## Summary
- `docker`/`kubectl` items forked their CLI unconditionally every render just to read the current context. Both now parse the relevant config file directly (`~/.docker/config.json`'s `currentContext`, `~/.kube/config`'s `current-context`/`namespace`) with builtins only.
- kubectl falls back to invoking the CLI when `$KUBECONFIG` lists multiple merged files or the default file doesn't exist, so nothing breaks for merged-config setups.

Split out of #66, which also bundled an unrelated version-caching change that turned out to have a correctness bug and was dropped. Supersedes #75 (closed), rebased onto current main and split into two commits — one per item — instead of one combined commit.

## Test plan
- [x] `mise run fmt`, `mise run lint`, `mise run test` — all green
- Rewrote `tests/_tide_item_docker.test.fish` and `tests/_tide_item_kubectl.test.fish` to use config-file fixtures for the new builtin-parsing path, while keeping CLI-mock cases as regression coverage for the fallback paths (missing file, multi-path `$KUBECONFIG`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)