### PR TITLE
chore(mise): remove all task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,3 @@ file = 'scripts/test_clean.fish'
 [tasks.clean]
 description = 'Remove generated test helper'
 run = 'rm -f littlecheck.py'
-
-[tasks.all]
-description = 'Format, lint, install, and test'
-depends = ['fmt', 'lint', 'install', 'test']


### PR DESCRIPTION
## Summary
- Removes `mise.toml`'s `tasks.all` task, which chained `fmt`, `lint`, `install`, and `test`.

## Test plan
- [ ] `mise run fmt`, `mise run lint`, `mise run test` still work standalone