### PR TITLE
docs(contributing): document mise tasks individually

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,15 +51,20 @@ Examples:
 
 ## Mise Tasks
 
-Pretty self explanatory.
+Primary development tasks will be `fmt`, `lint`, and `test`.
 
-- `mise run all`
-- `mise run fmt`
-- `mise run lint`
-- `mise run install`
-- `mise run test`
-
-In general, just run `mise run all` to do everything.
+- `install`
+  - Installs the current state of the directory using fisher to your real fish
+    environment. This probably isn't what you intend to do.
+- `fmt`
+  - Formats files to meet fish standards. This is a must pass for PRs.
+- `lint`
+  - Validates that all files are valid fish files. This is also a must pass for PRs.
+- `test`
+  - Creates a local environment for testing and performs the tests. This will not
+    impact your real environment.
+- `test-clean`
+  - Cleans up the test homedir used by `test`.
 
 ### Specifics
 

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,3 @@ file = 'scripts/test_clean.fish'
 [tasks.clean]
 description = 'Remove generated test helper'
 run = 'rm -f littlecheck.py'
-
-[tasks.all]
-description = 'Format, lint, install, and test'
-depends = ['fmt', 'lint', 'install', 'test']


### PR DESCRIPTION
## Summary
- Updates the Mise Tasks section of CONTRIBUTING.md to list `install`, `fmt`, `lint`, `test`, and `test-clean` individually, replacing the old pointer to `mise run all`.
- Adds a warning that `install` touches your real fish environment.
- Depends on #88 (removes the `all` task this doc change reflects).

## Test plan
- [ ] Docs read correctly and match current `mise.toml` tasks