### PR TITLE
fix(prompt): drop superseded background renders via generation stamp

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -16,6 +16,13 @@ set -g $prompt_var
 set -q _tide_prompt_tmpdir || set -g _tide_prompt_tmpdir (mktemp -d)
 set -g _tide_prompt_tmpfile $_tide_prompt_tmpdir/prompt
 
+# Bumped on every dispatch and stamped into each job's output, so a job that
+# finishes after a newer one has already been dispatched -- e.g. a slow
+# in-repo render outliving a fast render for the directory `cd`ed into next
+# -- can be recognized as superseded and dropped instead of overwriting
+# fresher content.
+set -q _tide_render_gen || set -g _tide_render_gen 0
+
 set_color normal | read -l color_normal
 status fish-path | read -l fish_path
 
@@ -25,7 +32,15 @@ end
 
 # _tide_repaint prevents us from creating a second background job
 function _tide_refresh_prompt --on-signal SIGUSR1 --inherit-variable prompt_var
-    set -g $prompt_var (cat $_tide_prompt_tmpfile 2>/dev/null)
+    set -l rendered (cat $_tide_prompt_tmpfile 2>/dev/null)
+    # First line is the generation this job was dispatched at (see
+    # _tide_dispatch_render) -- a mismatch means a newer job has since been
+    # dispatched, so this result is stale and superseded; drop it rather
+    # than clobbering $prompt_var with old content. No repaint here is
+    # correct: the newer job has either already applied its own result or
+    # will signal on its own once it finishes.
+    test "$rendered[1]" = "$_tide_render_gen" || return
+    set -g $prompt_var $rendered[2..]
     set -g _tide_repaint
     commandline -f repaint
 end
@@ -60,15 +75,22 @@ function _tide_dispatch_render --inherit-variable prompt_var --inherit-variable 
         return
     end
 
+    set -g _tide_render_gen (math $_tide_render_gen + 1)
+
     # The job renders into a private scratch file (suffixed with its own
     # pid) and atomically renames it over the shared tmpfile, so the
-    # SIGUSR1 handler can never read a partial write from a newer job. The
-    # tmpfile path crosses into the job string-escaped and is expanded as a
-    # variable there, never re-parsed as syntax, so any TMPDIR is safe.
+    # SIGUSR1 handler can never read a partial write from a newer job. Its
+    # first line is stamped with the generation dispatched here (baked in
+    # as a literal below, not read back from the variable, since the job
+    # is a separate process) so _tide_refresh_prompt can recognize and
+    # drop a result superseded by a since-dispatched job. The tmpfile path
+    # crosses into the job string-escaped and is expanded as a variable
+    # there, never re-parsed as syntax, so any TMPDIR is safe.
     $fish_path -c "set _tide_pipestatus $_tide_pipestatus
 set _tide_parent_dirs $_tide_parent_dirs
 set _tide_prompt_tmpfile "(string escape -- $_tide_prompt_tmpfile)"
-PATH="(string escape "$PATH")" CMD_DURATION=$CMD_DURATION fish_key_bindings=$fish_key_bindings fish_bind_mode=$fish_bind_mode $argv[1] >\$_tide_prompt_tmpfile.\$fish_pid
+echo $_tide_render_gen >\$_tide_prompt_tmpfile.\$fish_pid
+PATH="(string escape "$PATH")" CMD_DURATION=$CMD_DURATION fish_key_bindings=$fish_key_bindings fish_bind_mode=$fish_bind_mode $argv[1] >>\$_tide_prompt_tmpfile.\$fish_pid
 command mv -f \$_tide_prompt_tmpfile.\$fish_pid \$_tide_prompt_tmpfile
 command kill -s USR1 $fish_pid 2>/dev/null" &
     builtin disown


### PR DESCRIPTION
## Summary
- After `cd`-ing out of a git repo, the prompt kept showing the old repo's git status and right-prompt items (node/rustc version, etc.), sometimes for a long, unpredictable time before clearing on its own.
- Root cause: background render jobs could finish out of order. The "kill the previous job" check only catches a job that has already started writing its scratch file, but `fish -c` takes real time to start up, so two renders could be in flight at once. Whichever finished *last* won, not whichever was dispatched last — and an in-repo render (git status forks, toolchain-version items) is reliably slower than a plain directory's render, so the stale one usually finished last.
- Fix: stamp each dispatched render with a generation number (`_tide_render_gen`, a plain in-memory global, no universal variables involved) and drop any result whose stamp doesn't match the latest dispatch, so a superseded render can no longer overwrite a fresher one.

## Test plan
- [x] `mise run lint`
- [x] `mise run test` (full littlecheck suite, including `tests/fish_prompt.test.fish` and `tests/fish_prompt_transient.test.fish`)
- [x] Isolated logic test reproducing the exact race (stale generation landing after a fresh one) confirms the stale result is dropped and `prompt_var` stays correct
- [x] Manual: `cd` into a git repo with toolchain files, then `cd ..`, confirm the prompt updates promptly and stays correct across repeats