### PR TITLE
fix(prompt): stop dash-led directories from breaking pwd truncation

### DIFF
--- a/functions/_tide_pwd.fish
+++ b/functions/_tide_pwd.fish
@@ -29,16 +29,16 @@ eval "function _tide_pwd
         if path is \$parent_dir/\$dir_section/\$tide_pwd_markers
             set split_output[\$i] \"$color_anchors\$dir_section$reset_to_color_dirs\"
         else if test \$_tide_pwd_len -gt \$dist_btwn_sides
-            string match -qr \"(?<trunc>\..|.)\" \$dir_section
+            string match -qr \"(?<trunc>\..|.)\" -- \$dir_section
 
             set -l glob \$parent_dir/\$trunc*/
             set -e glob[(contains -i \$parent_dir/\$dir_section/ \$glob; or echo 1..-1)] # This is faster than inverse string match
 
-            while string match -qr \"^\$parent_dir/\$(string escape --style=regex \$trunc)\" \$glob &&
-                    string match -qr \"(?<trunc>\$(string escape --style=regex \$trunc).)\" \$dir_section
+            while string match -qr \"^\$parent_dir/\$(string escape --style=regex -- \$trunc)\" -- \$glob &&
+                    string match -qr \"(?<trunc>\$(string escape --style=regex -- \$trunc).)\" -- \$dir_section
             end
             test -n \"\$trunc\" && set split_output[\$i] \"$color_truncated\$trunc$reset_to_color_dirs\" &&
-                string join / \$split_output | string length -V | read _tide_pwd_len
+                string join / -- \$split_output | string length -V | read _tide_pwd_len
         end
     end
 

--- a/tests/_tide_item_pwd.test.fish
+++ b/tests/_tide_item_pwd.test.fish
@@ -111,6 +111,18 @@ _pwd "$tmpdir/tmp/has spaces/foo" # CHECK: ~/tmp/has spaces/foo
 mkdir -p "$tmpdir/tmp/--has dashes/foo"
 _pwd "$tmpdir/tmp/--has dashes/foo" # CHECK: ~/tmp/--has dashes/foo
 
+# ---------- Truncation with a leading-dash directory (regression: upstream #668) ----------
+set -l longDashDir -alfa/bravo/charlie/delta/echo/foxtrot/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
+# trunc disambiguates against the sibling "--has dashes" dir made above
+_pwd $tmpdir/tmp/$longDashDir # CHECK: ~/t/-a/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
+
+# Same-prefix sibling forces the disambiguation loop to grow trunc past the
+# leading dash -- this used to hang because `string escape --style=regex`
+# choked on it without `--`.
+mkdir -p "$tmpdir/tmp/-alfahello"
+_pwd $tmpdir/tmp/$longDashDir # CHECK: ~/t/-alfa/b/c/d/e/f/golf/hotel/india/juliett/kilo/lima/mike/november/oscar/papa
+command rm -r "$tmpdir/tmp/-alfahello"
+
 mkdir -p "$tmpdir/tmp/has'quotes''/foo"
 _pwd "$tmpdir/tmp/has'quotes''/foo" # CHECK: ~/tmp/has'quotes''/foo
 


### PR DESCRIPTION
## Summary
- `_tide_pwd`'s truncation branch passed directory names to `string match`, `string escape`, and `string join` without `--`. A name starting with a dash was read as an option, breaking the prompt.
- Same bug as upstream [IlanCosman/tide#668](https://github.com/IlanCosman/tide/issues/668). Here it surfaces as a `test: Missing argument` error rather than a hang, since this fork hands prompts off through a tempfile instead of a shared universal variable.
- Adds `--` before each path-derived value in the truncation branch.

## Test plan
- [x] `mise run test` (full suite, including two new regression cases: a long dash-led directory, and a same-prefix sibling that forces the disambiguation loop past the dash)
- [x] `mise run fmt` / `mise run lint`