### PR TITLE
fix(kubectl): stop context names starting with "-" from being misread as a flag

### DIFF
--- a/functions/_tide_item_kubectl.fish
+++ b/functions/_tide_item_kubectl.fish
@@ -18,7 +18,7 @@ function _tide_item_kubectl
         # exist, or the file didn't parse as expected -- let kubectl itself
         # figure it out.
         kubectl config view --minify --output 'jsonpath={.current-context}/{..namespace}' 2>/dev/null | read -l context &&
-            _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' $context)
+            _tide_print_item kubectl $tide_kubectl_icon' ' (string replace -r '/(|default)$' '' -- $context)
         return
     end
 

--- a/tests/_tide_item_kubectl.test.fish
+++ b/tests/_tide_item_kubectl.test.fish
@@ -17,6 +17,11 @@ _kubectl # CHECK: ⎈ curr-context
 mock kubectl "config view --minify --output" "echo curr-context/"
 _kubectl # CHECK: ⎈ curr-context
 
+# regression: a context name starting with "-" must not be read as an
+# option by the `string replace` that strips the trailing "/default"
+mock kubectl "config view --minify --output" "echo -curr-context/default"
+_kubectl # CHECK: ⎈ -curr-context
+
 mock kubectl "config view --minify --output" "echo curr-context/curr-namespace"
 _kubectl # CHECK: ⎈ curr-context/curr-namespace
 


### PR DESCRIPTION
The CLI-fallback path in `_tide_item_kubectl.fish` (used when `$KUBECONFIG` lists multiple files, the default config doesn't exist, or the file didn't parse) passes kubectl's output straight to `string replace` without `--`:

```fish
string replace -r '/(|default)$' '' $context
```

A context named e.g. `-staging` makes `$context` start with `-`, so `string replace` reads it as an unknown option instead of the string to operate on. Same bug as the one just fixed in `_tide_pwd.fish` (#98), just in a different file.

Add `--` before `$context`, and a regression test for a context name starting with `-`.