### PR TITLE
ci: add concurrency group to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-please-${{ github.ref }}
+  # Queue overlapping runs instead of cancelling: an in-progress run may have
+  # already tagged a release, and cancelling mid-run could leave that state
+  # half-applied.
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
- Add a `concurrency` group to the release-please workflow, keyed on `github.ref` (always `main`, since the workflow only triggers on push to `main`).
- Use `cancel-in-progress: false` so overlapping runs queue instead of racing — an in-progress run may have already tagged a release, and cancelling mid-run could leave that half-applied.

## Why
Pushes to `main` can land back to back — including from a stacked-PR merge that lands several layers in quick succession. Without a concurrency group, that could kick off overlapping release-please runs.

## Test plan
- [x] `actionlint .github/workflows/release-please.yml` passes